### PR TITLE
Generic server-side streaming RPC client for Java

### DIFF
--- a/examples/java/src/main/java/com/example/BearRoboticsClient.java
+++ b/examples/java/src/main/java/com/example/BearRoboticsClient.java
@@ -1,0 +1,181 @@
+package com.example;
+
+import com.example.auth.BearAuthService;
+import com.example.auth.JwtCredentials;
+import com.example.streaming.StreamingClient;
+import com.example.streaming.StreamingRpcMethod;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.stub.StreamObserver;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Logger;
+
+import bearrobotics.api.v1.services.cloud.APIServiceGrpc;
+
+/**
+ * Generic client for Bear Robotics Cloud API.
+ * Provides authenticated gRPC connections and streaming capabilities.
+ */
+public class BearRoboticsClient {
+    private static final Logger logger = Logger.getLogger(BearRoboticsClient.class.getName());
+    private static final String CREDENTIALS_PATH = "src/main/resources/credentials.json";
+
+    private final ManagedChannel channel;
+    private final BearAuthService authService;
+    private final JwtCredentials credentials;
+    private final AtomicBoolean running = new AtomicBoolean(true);
+
+    // Stub instances
+    private final APIServiceGrpc.APIServiceStub asyncStub;
+    private final APIServiceGrpc.APIServiceBlockingStub blockingStub;
+
+    /**
+     * Initialize the gRPC client with TLS and JWT authentication.
+     *
+     * @param host The host to connect to
+     * @param port The port to connect to
+     * @throws IOException If there's an error initializing authentication
+     */
+    public BearRoboticsClient(String host, int port) throws IOException {
+        this(host, port, CREDENTIALS_PATH);
+    }
+
+    /**
+     * Initialize the gRPC client with TLS and JWT authentication using custom credentials path.
+     *
+     * @param host The host to connect to
+     * @param port The port to connect to
+     * @param credentialsPath Path to the credentials JSON file
+     * @throws IOException If there's an error initializing authentication
+     */
+    public BearRoboticsClient(String host, int port, String credentialsPath) throws IOException {
+        // Initialize auth service
+        this.authService = new BearAuthService(credentialsPath);
+
+        // Create the JWT credentials
+        this.credentials = new JwtCredentials(authService);
+
+        // Build the channel with TLS and keep-alive options for long-running connections
+        channel = ManagedChannelBuilder.forAddress(host, port)
+                .useTransportSecurity() // Use TLS for secure connection
+                .keepAliveTime(30, TimeUnit.SECONDS) // Send keepalive ping every 30 seconds
+                .keepAliveTimeout(10, TimeUnit.SECONDS) // Wait 10 seconds for ping ack before considering connection dead
+                .build();
+
+        // Create the stubs with authentication
+        asyncStub = APIServiceGrpc.newStub(channel).withCallCredentials(this.credentials);
+        blockingStub = APIServiceGrpc.newBlockingStub(channel).withCallCredentials(this.credentials);
+
+        logger.info("Bear Robotics gRPC client initialized with TLS and JWT authentication using v1 API");
+    }
+
+    /**
+     * Get the async stub for making asynchronous calls.
+     *
+     * @return The async stub
+     */
+    public APIServiceGrpc.APIServiceStub getAsyncStub() {
+        return asyncStub;
+    }
+
+    /**
+     * Get the blocking stub for making synchronous calls.
+     *
+     * @return The blocking stub
+     */
+    public APIServiceGrpc.APIServiceBlockingStub getBlockingStub() {
+        return blockingStub;
+    }
+
+    /**
+     * Get the JWT credentials for error handling.
+     *
+     * @return The JWT credentials
+     */
+    public JwtCredentials getCredentials() {
+        return credentials;
+    }
+
+    /**
+     * Create a streaming client for any streaming RPC.
+     *
+     * @param <TRequest> The request type
+     * @param <TResponse> The response type
+     * @return A StreamingClient builder
+     */
+    public <TRequest, TResponse> StreamingClient.Builder<TRequest, TResponse> createStreamingClient() {
+        return new StreamingClient.Builder<TRequest, TResponse>().credentials(credentials);
+    }
+
+    /**
+     * Create and start a streaming client with the provided configuration.
+     *
+     * @param rpcMethod The streaming RPC method to call
+     * @param request The request to send
+     * @param observer Stream observer for handling responses, errors, and completion
+     * @param streamName Name of the stream for logging
+     * @param <TRequest> The request type
+     * @param <TResponse> The response type
+     * @return The configured and started streaming client
+     * @throws InterruptedException If interrupted while starting the stream
+     */
+    public <TRequest, TResponse> StreamingClient<TRequest, TResponse> startStream(
+            StreamingRpcMethod<TRequest, TResponse> rpcMethod,
+            TRequest request,
+            StreamObserver<TResponse> observer,
+            String streamName) throws InterruptedException {
+
+        StreamingClient<TRequest, TResponse> client = new StreamingClient.Builder<TRequest, TResponse>()
+                .rpcMethod(rpcMethod)
+                .request(request)
+                .observer(observer)
+                .streamName(streamName)
+                .credentials(credentials)
+                .build();
+
+        // Start streaming in a separate thread
+        Thread streamThread = new Thread(() -> {
+            try {
+                client.startStreaming();
+            } catch (InterruptedException e) {
+                logger.info("Streaming thread interrupted for " + streamName);
+                Thread.currentThread().interrupt();
+            }
+        });
+        streamThread.setName(streamName + "-Thread");
+        streamThread.start();
+
+        return client;
+    }
+
+    /**
+     * Check if the client is running.
+     *
+     * @return true if the client is running, false otherwise
+     */
+    public boolean isRunning() {
+        return running.get();
+    }
+
+    /**
+     * Shutdown the client and clean up resources.
+     *
+     * @throws InterruptedException If interrupted while shutting down
+     */
+    public void shutdown() throws InterruptedException {
+        // Signal running threads to stop
+        running.set(false);
+
+        // Shutdown auth service
+        authService.shutdown();
+
+        // Shutdown channel
+        channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
+        logger.info("Bear Robotics gRPC client shutdown completed");
+    }
+}
+

--- a/examples/java/src/main/java/com/example/Main.java
+++ b/examples/java/src/main/java/com/example/Main.java
@@ -1,265 +1,234 @@
 package com.example;
 
-import com.example.auth.BearAuthService;
-import com.example.auth.JwtCredentials;
-
-import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
-import io.grpc.Status;
+import com.example.streaming.StreamingClient;
 import io.grpc.stub.StreamObserver;
 
 import java.io.IOException;
-import java.util.EnumSet;
-import java.util.Set;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
-// Import the generated gRPC classes for v0 API
-import bearrobotics.api.v0.cloud.CloudAPIServiceGrpc;
-import bearrobotics.api.v0.cloud.CloudApiService.SubscribeMissionStatusRequest;
-import bearrobotics.api.v0.cloud.CloudApiService.SubscribeMissionStatusResponse;
-import bearrobotics.api.v0.robot.MissionOuterClass.MissionState;
+import bearrobotics.api.v1.core.FleetSelector.RobotSelector;
+import bearrobotics.api.v1.services.cloud.ApiService.*;
 
+/**
+ * Examples demonstrating different ways to use the generic streaming client.
+ * This class shows various patterns and use cases for streaming gRPC calls.
+ */
 public class Main {
     private static final Logger logger = Logger.getLogger(Main.class.getName());
-    private static final String CREDENTIALS_PATH = "src/main/resources/credentials.json";
 
-    // Set of status codes that should trigger a retry
-    private static final Set<Status.Code> RETRYABLE_STATUS_CODES = EnumSet.of(
-        Status.Code.UNAVAILABLE,    // Server is temporarily unavailable
-        Status.Code.INTERNAL,       // Server encountered an internal error
-        Status.Code.DEADLINE_EXCEEDED, // Request deadline exceeded
-        Status.Code.UNAUTHENTICATED // Authentication failure - handled separately
-    );
+    private final BearRoboticsClient client;
 
-    private final ManagedChannel channel;
-    private final CloudAPIServiceGrpc.CloudAPIServiceStub asyncStub;
-    private final BearAuthService authService;
-    private final AtomicBoolean running = new AtomicBoolean(true);
+    public Main(BearRoboticsClient client) {
+        this.client = client;
+    }
 
     /**
-     * Initialize the gRPC client with TLS and JWT authentication.
-     *
-     * @param host The host to connect to
-     * @param port The port to connect to
-     * @throws IOException If there's an error initializing authentication
+     * Example 1: Battery status streaming with custom error handling.
+     * Shows how to implement custom error handling and completion logic.
      */
-    public Main(String host, int port) throws IOException {
-        // Initialize auth service
-        this.authService = new BearAuthService(CREDENTIALS_PATH);
+    public void basicBatteryStatusExample(String robotId) throws InterruptedException {
+        logger.info("=== Mission Status Example ===");
 
-        // Create the JWT credentials
-        JwtCredentials credentials = new JwtCredentials(authService);
-
-        // Build the channel with TLS and keep-alive options for long-running connections
-        channel = ManagedChannelBuilder.forAddress(host, port)
-                .useTransportSecurity() // Use TLS for secure connection
-                .keepAliveTime(30, TimeUnit.SECONDS) // Send keepalive ping every 30 seconds
-                .keepAliveTimeout(10, TimeUnit.SECONDS) // Wait 10 seconds for ping ack before considering connection dead
+        RobotSelector selector = RobotSelector.newBuilder()
+                .setRobotIds(RobotSelector.RobotIDs.newBuilder()
+                    .addIds(robotId)
+                    .build())
                 .build();
 
-        // Create the async stub with authentication
-        asyncStub = CloudAPIServiceGrpc.newStub(channel)
-                .withCallCredentials(credentials);
+        SubscribeBatteryStatusRequest request = SubscribeBatteryStatusRequest.newBuilder()
+                .setSelector(selector)
+                .build();
 
-        logger.info("gRPC client initialized with TLS and JWT authentication using v0 API");
-    }
-
-    public void shutdown() throws InterruptedException {
-        // Signal running threads to stop
-        running.set(false);
-
-        // Shutdown auth service
-        authService.shutdown();
-
-        // Shutdown channel
-        channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
-        logger.info("gRPC client shutdown completed");
-    }
-
-    /**
-     * Subscribe to mission status updates using server-side streaming RPC.
-     * This method demonstrates how to handle a streaming response from the server.
-     * It also includes selective auto-reconnection for specific error codes.
-     * This subscription runs indefinitely until the application is shut down.
-     *
-     * @param robotId The ID of the robot to subscribe to
-     */
-    public void subscribeMissionStatus(String robotId) throws InterruptedException {
-        logger.info("Subscribing to mission status for robot: " + robotId + " using v0 API (indefinite subscription)");
-
-        // Create a countdown latch that will only be triggered on shutdown or error
-        final CountDownLatch terminationLatch = new CountDownLatch(1);
-
-        // Create a stream observer with selective reconnection logic
-        subscribeMissionStatusWithReconnect(robotId, new StreamObserver<SubscribeMissionStatusResponse>() {
+        // Custom stream observer with detailed logging and error handling
+        StreamObserver<SubscribeBatteryStatusResponse> observer = new StreamObserver<SubscribeBatteryStatusResponse>() {
             @Override
-            public void onNext(SubscribeMissionStatusResponse response) {
-                MissionState missionState = response.getMissionState();
-                logger.info("Received mission status update for robot: " + robotId);
-                logger.info("Message: " + missionState);
+            public void onNext(SubscribeBatteryStatusResponse response) {
+                logger.info("Robot ID: " + response.getRobotId());
+                logger.info("Battery percent: " + response.getBatteryState().getChargePercent());
+                logger.info("Charge method: " + response.getBatteryState().getChargeMethod());
             }
 
             @Override
-            public void onError(Throwable t) {
-                Status status = Status.fromThrowable(t);
-                Status.Code code = status.getCode();
-
-                logger.log(Level.SEVERE, "CAUSE: {0}", t.getCause());
-                logger.log(Level.WARNING, "Mission status subscription failed: {0} (Code: {1})",
-                        new Object[]{t.getMessage(), code});
-
-                // Check if we should retry based on the status code
-                boolean shouldRetry = running.get() && RETRYABLE_STATUS_CODES.contains(code);
-
-                if (shouldRetry) {
-                    // Special handling for authentication errors
-                    if (code == Status.Code.UNAUTHENTICATED) {
-                        logger.warning("Authentication error detected. Token may have expired and will be refreshed.");
-                    }
-
-                    logger.info("Error is retryable (Status code: " + code + "). Will attempt to reconnect...");
-                } else {
-                    logger.info("Error is NOT retryable (Status code: " + code + "). Will not reconnect.");
-                    terminationLatch.countDown();
-                }
+            public void onError(Throwable error) {
+                logger.severe("Custom error handler triggered: " + error.getMessage());
+                // You could implement custom error handling logic here
+                // For example: send alerts, log to external systems, etc.
             }
 
             @Override
             public void onCompleted() {
-                logger.info("Mission status subscription completed by server");
-
-                // Only count down if we're shutting down
-                if (!running.get()) {
-                    terminationLatch.countDown();
-                } else {
-                    // We don't automatically reconnect when the server completes the stream normally
-                    // Only specific errors will trigger reconnection
-                    logger.info("Server gracefully completed the stream. Subscription ended.");
-                    terminationLatch.countDown();
-                }
-            }
-        });
-
-        // Wait indefinitely for the application to be terminated
-        logger.info("Subscription is active and will run indefinitely until application shutdown or non-retryable error");
-        terminationLatch.await();
-    }
-
-    /**
-     * Subscribes to mission status with selective reconnection logic.
-     * This only reconnects for specific status codes.
-     *
-     * @param robotId The robot ID to subscribe to
-     * @param observer The observer to receive events
-     */
-    private void subscribeMissionStatusWithReconnect(String robotId, StreamObserver<SubscribeMissionStatusResponse> observer) {
-        // Create a wrapper observer that handles reconnection
-        StreamObserver<SubscribeMissionStatusResponse> reconnectingObserver = new StreamObserver<SubscribeMissionStatusResponse>() {
-            @Override
-            public void onNext(SubscribeMissionStatusResponse response) {
-                observer.onNext(response);
-            }
-
-            @Override
-            public void onError(Throwable t) {
-                // Extract the gRPC status code
-                Status status = Status.fromThrowable(t);
-                Status.Code code = status.getCode();
-
-                // Forward the error to the original observer
-                observer.onError(t);
-
-                // Attempt to reconnect only for specific status codes and if we're still running
-                if (running.get() && RETRYABLE_STATUS_CODES.contains(code)) {
-                    try {
-                        int delaySeconds = 5;
-                        logger.info("Reconnecting after error (" + code + ") in " + delaySeconds + " seconds...");
-                        Thread.sleep(delaySeconds * 1000); // Wait before reconnecting
-
-                        // Subscribe again if we're still running
-                        if (running.get()) {
-                            logger.info("Resubscribing to mission status for robot: " + robotId);
-                            subscribeMissionStatusWithReconnect(robotId, observer);
-                        }
-                    } catch (InterruptedException e) {
-                        logger.log(Level.WARNING, "Reconnection interrupted", e);
-                        Thread.currentThread().interrupt();
-                    }
-                } else {
-                    logger.info("Not reconnecting for status code: " + code);
-                }
-            }
-
-            @Override
-            public void onCompleted() {
-                // Forward the completion event
-                observer.onCompleted();
-
-                // We don't reconnect on normal completion
-                logger.info("Stream completed normally by server, not reconnecting");
+                logger.info("Custom completion handler: Mission status stream ended gracefully");
+                // You could implement cleanup logic here
             }
         };
 
-        // Build the request with robot ID
-        SubscribeMissionStatusRequest request = SubscribeMissionStatusRequest.newBuilder()
-                .setRobotId(robotId)
+        StreamingClient<SubscribeBatteryStatusRequest, SubscribeBatteryStatusResponse> streamingClient =
+            client.<SubscribeBatteryStatusRequest, SubscribeBatteryStatusResponse>createStreamingClient()
+                .rpcMethod(client.getAsyncStub()::subscribeBatteryStatus)
+                .request(request)
+                .observer(observer)
+                .streamName("Mission Status")
+                .reconnectDelay(10) // Custom reconnect delay of 10 seconds
                 .build();
 
-        // Make the call with the reconnecting observer
-        asyncStub.subscribeMissionStatus(request, reconnectingObserver);
+        streamingClient.startStreaming();
     }
 
+    /**
+     * Example 2: Multiple concurrent streams.
+     * Shows how to run multiple streaming clients simultaneously.
+     */
+    public void multipleConcurrentStreamsExample(String robotId) throws InterruptedException {
+        logger.info("=== Multiple Concurrent Streams Example ===");
+
+        CountDownLatch allStreamsLatch = new CountDownLatch(2);
+
+        // Start mission status stream in background thread
+        Thread missionThread = new Thread(() -> {
+            try {
+                RobotSelector missionSelector = RobotSelector.newBuilder()
+                        .setRobotIds(RobotSelector.RobotIDs.newBuilder()
+                            .addIds(robotId)
+                            .build())
+                        .build();
+
+                SubscribeMissionStatusRequest missionRequest = SubscribeMissionStatusRequest.newBuilder()
+                        .setSelector(missionSelector)
+                        .build();
+
+                StreamObserver<SubscribeMissionStatusResponse> missionObserver = new StreamObserver<SubscribeMissionStatusResponse>() {
+                    @Override
+                    public void onNext(SubscribeMissionStatusResponse response) {
+                        logger.info("[MISSION-THREAD] Robot: " + response.getRobotId() + " - " + response.getMissionState());
+                    }
+
+                    @Override
+                    public void onError(Throwable error) {
+                        logger.severe("[MISSION-THREAD] Error: " + error.getMessage());
+                        allStreamsLatch.countDown();
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                        logger.info("[MISSION-THREAD] Stream completed");
+                        allStreamsLatch.countDown();
+                    }
+                };
+
+                StreamingClient<SubscribeMissionStatusRequest, SubscribeMissionStatusResponse> missionClient =
+                    client.<SubscribeMissionStatusRequest, SubscribeMissionStatusResponse>createStreamingClient()
+                        .rpcMethod(client.getAsyncStub()::subscribeMissionStatus)
+                        .request(missionRequest)
+                        .observer(missionObserver)
+                        .streamName("Concurrent Mission Status")
+                        .build();
+
+                missionClient.startStreaming();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                allStreamsLatch.countDown();
+            }
+        });
+
+        // Start robot status stream in background thread
+        Thread statusThread = new Thread(() -> {
+            try {
+                RobotSelector selector = RobotSelector.newBuilder()
+                        .setRobotIds(RobotSelector.RobotIDs.newBuilder()
+                            .addIds(robotId)
+                            .build())
+                        .build();
+
+                SubscribeRobotStatusRequest statusRequest = SubscribeRobotStatusRequest.newBuilder()
+                        .setSelector(selector)
+                        .build();
+
+                StreamObserver<SubscribeRobotStatusResponse> statusObserver = new StreamObserver<SubscribeRobotStatusResponse>() {
+                    @Override
+                    public void onNext(SubscribeRobotStatusResponse response) {
+                        logger.info("[STATUS-THREAD] Robot: " + response.getRobotId() + " - " + response.getRobotState());
+                    }
+
+                    @Override
+                    public void onError(Throwable error) {
+                        logger.severe("[STATUS-THREAD] Error: " + error.getMessage());
+                        allStreamsLatch.countDown();
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                        logger.info("[STATUS-THREAD] Stream completed");
+                        allStreamsLatch.countDown();
+                    }
+                };
+
+                StreamingClient<SubscribeRobotStatusRequest, SubscribeRobotStatusResponse> statusClient =
+                    client.<SubscribeRobotStatusRequest, SubscribeRobotStatusResponse>createStreamingClient()
+                        .rpcMethod(client.getAsyncStub()::subscribeRobotStatus)
+                        .request(statusRequest)
+                        .observer(statusObserver)
+                        .streamName("Concurrent Robot Status")
+                        .build();
+
+                statusClient.startStreaming();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                allStreamsLatch.countDown();
+            }
+        });
+
+        missionThread.setName("MissionStreamThread");
+        statusThread.setName("StatusStreamThread");
+
+        missionThread.start();
+        statusThread.start();
+
+        // Wait for both streams to complete
+        allStreamsLatch.await();
+        logger.info("All concurrent streams completed");
+    }
+
+    /**
+     * Main method to run the examples.
+     */
     public static void main(String[] args) {
-        // Default values
-        String host = "api-beta.bearrobotics.ai";
+        String host = "api.bearrobotics.ai";
         int port = 443;
-        String robotId = "robot-1";
+        String robotId = args.length > 0 ? args[0] : "robot-1";
+        String example = args.length > 1 ? args[1] : "basic";
 
-        // Adjust based on command line arguments if provided
-        if (args.length >= 1) robotId = args[0];
-
-        Main client = null;
         try {
-            client = new Main(host, port);
+            BearRoboticsClient client = new BearRoboticsClient(host, port);
+            Main examples = new Main(client);
 
-            // Register shutdown hook to clean up resources
-            final Main finalClient = client;
+            // Register shutdown hook
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
                 try {
-                    logger.info("Shutdown hook triggered, shutting down client...");
-                    finalClient.shutdown();
+                    client.shutdown();
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                 }
             }));
 
-            logger.info("Starting indefinite mission status subscription for robot: " + robotId);
-            logger.info("Will only reconnect on status codes: UNAVAILABLE, INTERNAL, DEADLINE_EXCEEDED, UNAUTHENTICATED");
-
-            // Subscribe to mission status updates indefinitely
-            client.subscribeMissionStatus(robotId);
-
-            // This line will only be reached if the subscription terminates
-            logger.info("Mission status subscription ended");
-        } catch (IOException e) {
-            logger.log(Level.SEVERE, "Error initializing authentication", e);
-        } catch (InterruptedException e) {
-            logger.log(Level.WARNING, "Client interrupted", e);
-            Thread.currentThread().interrupt();
-        } finally {
-            // Ensure we clean up resources
-            if (client != null) {
-                try {
-                    client.shutdown();
-                } catch (InterruptedException e) {
-                    logger.log(Level.WARNING, "Shutdown interrupted", e);
-                    Thread.currentThread().interrupt();
-                }
+            switch (example.toLowerCase()) {
+                case "basic":
+                    examples.basicBatteryStatusExample(robotId);
+                    break;
+                case "concurrent":
+                    examples.multipleConcurrentStreamsExample(robotId);
+                    break;
+                default:
+                    logger.severe("Unknown example: " + example);
+                    logger.info("Available examples: basic, concurrent");
+                    return;
             }
+
+        } catch (IOException e) {
+            logger.severe("Failed to initialize client: " + e.getMessage());
+        } catch (InterruptedException e) {
+            logger.info("Examples interrupted");
+            Thread.currentThread().interrupt();
         }
     }
 }

--- a/examples/java/src/main/java/com/example/auth/BearAuthService.java
+++ b/examples/java/src/main/java/com/example/auth/BearAuthService.java
@@ -25,41 +25,38 @@ public class BearAuthService {
     private static final String AUTH_URL = "https://api-auth.bearrobotics.ai/authorizeApiAccess";
     private static final MediaType JSON = MediaType.parse("application/json");
     private static final ObjectMapper objectMapper = new ObjectMapper();
-    
+
     // Token refresh scheduler
     private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
-    
-    // Token validity period in milliseconds (1 hour by default)
-    private static final long TOKEN_VALIDITY_PERIOD = 60 * 60 * 1000; // 1 hour
-    
+
     // How often to refresh the token (30 minutes)
     private static final long TOKEN_REFRESH_INTERVAL = 30 * 60 * 1000; // 30 minutes
-    
+
     private String apiKey;
     private String secret;
     private String scope;
     private String jwtToken;
-    private long tokenExpirationTime;
-    
+    private long lastTokenRefreshTime;
+
     // Token listeners to notify when token is refreshed
     private TokenRefreshListener tokenListener;
-    
+
     private final OkHttpClient httpClient = new OkHttpClient.Builder()
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
             .writeTimeout(30, TimeUnit.SECONDS)
             .build();
-    
+
     /**
      * Interface for components that need to be notified when the token is refreshed.
      */
     public interface TokenRefreshListener {
         void onTokenRefreshed(String newToken);
     }
-    
+
     /**
      * Initializes the auth service by loading credentials from a file.
-     * 
+     *
      * @param credentialsFilePath Path to the credentials JSON file
      * @throws IOException If there's an error reading the credentials file
      */
@@ -70,58 +67,77 @@ public class BearAuthService {
         // Start token refresh scheduler
         startTokenRefreshScheduler();
     }
-    
+
     /**
      * Sets a listener to be notified when the token is refreshed.
-     * 
+     *
      * @param listener The listener to notify
      */
     public void setTokenRefreshListener(TokenRefreshListener listener) {
         this.tokenListener = listener;
     }
-    
+
     /**
      * Loads API credentials from the specified file path.
-     * 
+     *
      * @param filePath Path to the credentials JSON file
      * @throws IOException If there's an error reading the file
      */
     private void loadCredentials(String filePath) throws IOException {
         Path path = Paths.get(filePath);
-        
+
         if (!Files.exists(path)) {
             throw new IOException("Credentials file not found: " + filePath);
         }
-        
+
         try (InputStream is = Files.newInputStream(path)) {
             JsonNode credentials = objectMapper.readTree(is);
             this.apiKey = credentials.get("api_key").asText();
             this.secret = credentials.get("secret").asText();
             this.scope = credentials.get("scope").asText();
-            
+
             logger.info("Credentials loaded successfully");
         }
     }
-    
+
     /**
      * Gets a valid JWT token for API authentication.
-     * If the token is expired or not yet obtained, a new one will be fetched.
-     * 
+     * If no token exists or the refresh interval has passed, a new one will be fetched.
+     *
      * @return The JWT token
      * @throws IOException If there's an error fetching the token
      */
     public synchronized String getJwtToken() throws IOException {
         // Check if we need to fetch a new token
-        if (jwtToken == null || System.currentTimeMillis() > tokenExpirationTime) {
+        if (jwtToken == null || shouldRefreshToken()) {
             fetchNewToken();
         }
-        
+
         return jwtToken;
     }
-    
+
+    /**
+     * Forces a token refresh. Used when we receive authentication errors from the server.
+     *
+     * @throws IOException If there's an error fetching the token
+     */
+    public synchronized void forceTokenRefresh() throws IOException {
+        logger.info("Forcing token refresh due to authentication error");
+        fetchNewToken();
+    }
+
+    /**
+     * Checks if the token should be refreshed based on the refresh interval.
+     *
+     * @return true if the token should be refreshed
+     */
+    private boolean shouldRefreshToken() {
+        return System.currentTimeMillis() - lastTokenRefreshTime >= TOKEN_REFRESH_INTERVAL;
+    }
+
     /**
      * Fetches a new JWT token from the authentication API.
-     * 
+     *
      * @throws IOException If there's an error in the API call
      */
     private synchronized void fetchNewToken() throws IOException {
@@ -130,39 +146,40 @@ public class BearAuthService {
         requestBody.put("api_key", apiKey);
         requestBody.put("secret", secret);
         requestBody.put("scope", scope);
-        
+
         String requestBodyJson = objectMapper.writeValueAsString(requestBody);
-        
+        logger.info(requestBodyJson);
+        logger.info(AUTH_URL);
+
         // Build the request
         RequestBody body = RequestBody.create(requestBodyJson, JSON);
         Request request = new Request.Builder()
                 .url(AUTH_URL)
                 .post(body)
                 .build();
-        
+
         logger.info("Fetching new JWT token...");
-        
+
         // Execute the request
         try (Response response = httpClient.newCall(request).execute()) {
             if (!response.isSuccessful()) {
-                throw new IOException("Failed to obtain JWT token: " + 
+                throw new IOException("Failed to obtain JWT token: " +
                         response.code() + " " + response.message());
             }
-            
+
             if (response.body() == null) {
                 throw new IOException("Empty response received from auth API");
             }
-            
+
             // The response body is a plain string containing the JWT token
             String newToken = response.body().string();
-            
-            // Update token and expiration time
+
+            // Update token and refresh time
             this.jwtToken = newToken;
-            // Set expiration time to current time + token validity period
-            this.tokenExpirationTime = System.currentTimeMillis() + TOKEN_VALIDITY_PERIOD;
-            
-            logger.info("JWT token obtained successfully, valid for 1 hour. Will refresh in 30 minutes.");
-            
+            this.lastTokenRefreshTime = System.currentTimeMillis();
+
+            logger.info("JWT token obtained successfully. Will refresh in 30 minutes.");
+
             // Notify listener if registered
             if (tokenListener != null) {
                 tokenListener.onTokenRefreshed(newToken);
@@ -172,7 +189,7 @@ public class BearAuthService {
             throw new IOException("Failed to obtain JWT token", e);
         }
     }
-    
+
     /**
      * Starts a background scheduler to automatically refresh the token every 30 minutes.
      */
@@ -186,10 +203,20 @@ public class BearAuthService {
                 logger.log(Level.SEVERE, "Scheduled token refresh failed", e);
             }
         }, TOKEN_REFRESH_INTERVAL, TOKEN_REFRESH_INTERVAL, TimeUnit.MILLISECONDS);
-        
+
         logger.info("Token refresh scheduler started - will refresh token every 30 minutes");
     }
-    
+
+    /**
+     * Simulates an authentication error by invalidating the current token.
+     * This is useful for testing authentication error handling.
+     */
+    public synchronized void simulateAuthenticationError() {
+        logger.info("Simulating authentication error - invalidating current token");
+        this.jwtToken = "invalid_token_for_testing";
+        this.lastTokenRefreshTime = 0; // Force refresh on next request
+    }
+
     /**
      * Shuts down the token refresh scheduler.
      */

--- a/examples/java/src/main/java/com/example/auth/JwtCredentials.java
+++ b/examples/java/src/main/java/com/example/auth/JwtCredentials.java
@@ -3,6 +3,7 @@ package com.example.auth;
 import io.grpc.CallCredentials;
 import io.grpc.Metadata;
 import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 
 import java.util.concurrent.Executor;
 import java.util.logging.Level;
@@ -16,12 +17,12 @@ public class JwtCredentials extends CallCredentials implements BearAuthService.T
     private static final Logger logger = Logger.getLogger(JwtCredentials.class.getName());
     private static final Metadata.Key<String> AUTHORIZATION_METADATA_KEY = Metadata.Key.of(
             "Authorization", Metadata.ASCII_STRING_MARSHALLER);
-    
+
     private final BearAuthService authService;
-    
+
     /**
      * Creates new JWT credentials that automatically renew tokens.
-     * 
+     *
      * @param authService The authentication service to use
      */
     public JwtCredentials(BearAuthService authService) {
@@ -29,18 +30,18 @@ public class JwtCredentials extends CallCredentials implements BearAuthService.T
         // Register to receive token refresh notifications
         this.authService.setTokenRefreshListener(this);
     }
-    
+
     @Override
     public void applyRequestMetadata(RequestInfo requestInfo, Executor appExecutor, MetadataApplier applier) {
         appExecutor.execute(() -> {
             try {
                 // Get JWT token (will be refreshed automatically if needed)
                 String token = authService.getJwtToken();
-                
+
                 // Apply the token to the request metadata
                 Metadata headers = new Metadata();
                 headers.put(AUTHORIZATION_METADATA_KEY, "Bearer " + token);
-                
+
                 applier.apply(headers);
             } catch (Throwable e) {
                 logger.log(Level.SEVERE, "Failed to apply JWT credentials", e);
@@ -49,22 +50,48 @@ public class JwtCredentials extends CallCredentials implements BearAuthService.T
             }
         });
     }
-    
+
+    /**
+     * Handles authentication errors by forcing a token refresh.
+     * This should be called when an UNAUTHENTICATED error is received from the server.
+     */
+    public void handleAuthenticationError() {
+        try {
+            logger.info("Handling authentication error - forcing token refresh");
+            authService.forceTokenRefresh();
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Failed to refresh token after authentication error", e);
+        }
+    }
+
+    /**
+     * Checks if the given throwable is an authentication error that should trigger token refresh.
+     *
+     * @param throwable The throwable to check
+     * @return true if this is an authentication error
+     */
+    public static boolean isAuthenticationError(Throwable throwable) {
+        if (throwable instanceof StatusRuntimeException) {
+            StatusRuntimeException sre = (StatusRuntimeException) throwable;
+            return sre.getStatus().getCode() == Status.Code.UNAUTHENTICATED;
+        }
+        return false;
+    }
+
     /**
      * Called when the token is refreshed.
      * For long-running gRPC calls, this doesn't automatically update the current connection,
      * but ensures that new calls will use the new token.
-     * 
+     *
      * @param newToken The new JWT token
      */
     @Override
     public void onTokenRefreshed(String newToken) {
         logger.info("JWT token refreshed, new connections will use the updated token");
     }
-    
+
     // Note: This method is deprecated but still required by the interface.
     // The warning can be suppressed as it's part of the API we need to implement.
-    @SuppressWarnings("deprecation")
     @Override
     public void thisUsesUnstableApi() {
         // Required by the interface but not used

--- a/examples/java/src/main/java/com/example/streaming/StreamingClient.java
+++ b/examples/java/src/main/java/com/example/streaming/StreamingClient.java
@@ -1,0 +1,299 @@
+package com.example.streaming;
+
+import com.example.auth.JwtCredentials;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Generic streaming client for gRPC server-side streaming RPCs.
+ * Handles authentication, reconnection logic, and error handling for any streaming RPC.
+ *
+ * @param <TRequest> The request type for the streaming RPC
+ * @param <TResponse> The response type for the streaming RPC
+ */
+public class StreamingClient<TRequest, TResponse> {
+    private static final Logger logger = Logger.getLogger(StreamingClient.class.getName());
+
+    // Set of status codes that should trigger a retry
+    private static final Set<Status.Code> RETRYABLE_STATUS_CODES = EnumSet.of(
+        Status.Code.UNAVAILABLE,        // Server is temporarily unavailable
+        Status.Code.INTERNAL,           // Server encountered an internal error
+        Status.Code.DEADLINE_EXCEEDED,  // Request deadline exceeded
+        Status.Code.UNAUTHENTICATED     // Authentication failure - handled separately
+    );
+
+    private final StreamingRpcMethod<TRequest, TResponse> rpcMethod;
+    private final TRequest request;
+    private final StreamObserver<TResponse> observer;
+    private final AtomicBoolean running = new AtomicBoolean(true);
+    private final String streamName;
+    private final int reconnectDelaySeconds;
+    private final JwtCredentials credentials;
+
+    /**
+     * Creates a new streaming client.
+     *
+     * @param rpcMethod The streaming RPC method to call
+     * @param request The request to send
+     * @param observer Stream observer for handling responses, errors, and completion
+     * @param streamName Name of the stream for logging purposes
+     * @param credentials JWT credentials for authentication error handling
+     */
+    public StreamingClient(StreamingRpcMethod<TRequest, TResponse> rpcMethod,
+                          TRequest request,
+                          StreamObserver<TResponse> observer,
+                          String streamName,
+                          JwtCredentials credentials) {
+        this(rpcMethod, request, observer, streamName, 5, credentials);
+    }
+
+    /**
+     * Creates a new streaming client with custom reconnect delay.
+     *
+     * @param rpcMethod The streaming RPC method to call
+     * @param request The request to send
+     * @param observer Stream observer for handling responses, errors, and completion
+     * @param streamName Name of the stream for logging purposes
+     * @param reconnectDelaySeconds Delay before reconnecting after an error
+     * @param credentials JWT credentials for authentication error handling
+     */
+    public StreamingClient(StreamingRpcMethod<TRequest, TResponse> rpcMethod,
+                          TRequest request,
+                          StreamObserver<TResponse> observer,
+                          String streamName,
+                          int reconnectDelaySeconds,
+                          JwtCredentials credentials) {
+        this.rpcMethod = rpcMethod;
+        this.request = request;
+        this.observer = observer;
+        this.streamName = streamName;
+        this.reconnectDelaySeconds = reconnectDelaySeconds;
+        this.credentials = credentials;
+    }
+
+    /**
+     * Starts the streaming subscription.
+     * This method runs indefinitely until the application is shut down or a non-retryable error occurs.
+     *
+     * @throws InterruptedException If the thread is interrupted while waiting
+     */
+    public void startStreaming() throws InterruptedException {
+        logger.info("Starting " + streamName + " streaming (indefinite subscription)");
+
+        // Create a countdown latch that will only be triggered on shutdown or non-retryable error
+        final CountDownLatch terminationLatch = new CountDownLatch(1);
+
+        // Create the stream observer with reconnection logic
+        startStreamingWithReconnect(new StreamObserver<TResponse>() {
+            @Override
+            public void onNext(TResponse response) {
+                try {
+                    observer.onNext(response);
+                } catch (Exception e) {
+                    logger.log(Level.WARNING, "Error in response callback for " + streamName, e);
+                }
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                Status status = Status.fromThrowable(t);
+                Status.Code code = status.getCode();
+
+                logger.log(Level.SEVERE, "CAUSE: {0}", t.getCause());
+                logger.log(Level.WARNING, streamName + " streaming failed: {0} (Code: {1})",
+                        new Object[]{t.getMessage(), code});
+
+                // Call user's error callback
+                try {
+                    observer.onError(t);
+                } catch (Exception e) {
+                    logger.log(Level.WARNING, "Error in error callback for " + streamName, e);
+                }
+
+                // Check if we should retry based on the status code
+                boolean shouldRetry = running.get() && RETRYABLE_STATUS_CODES.contains(code);
+
+                if (shouldRetry) {
+                    // Special handling for authentication errors
+                    if (code == Status.Code.UNAUTHENTICATED) {
+                        logger.warning("Authentication error detected. Token may have expired and will be refreshed.");
+                    }
+
+                    logger.info("Error is retryable (Status code: " + code + "). Will attempt to reconnect...");
+                } else {
+                    logger.info("Error is NOT retryable (Status code: " + code + "). Will not reconnect.");
+                    terminationLatch.countDown();
+                }
+            }
+
+            @Override
+            public void onCompleted() {
+                logger.info(streamName + " streaming completed by server");
+
+                // Call user's completion callback
+                try {
+                    observer.onCompleted();
+                } catch (Exception e) {
+                    logger.log(Level.WARNING, "Error in completion callback for " + streamName, e);
+                }
+
+                // Only count down if we're shutting down
+                if (!running.get()) {
+                    terminationLatch.countDown();
+                } else {
+                    // We don't automatically reconnect when the server completes the stream normally
+                    logger.info("Server gracefully completed the stream. Subscription ended.");
+                    terminationLatch.countDown();
+                }
+            }
+        });
+
+        // Wait indefinitely for the application to be terminated
+        logger.info(streamName + " subscription is active and will run indefinitely until application shutdown or non-retryable error");
+        logger.info("Will only reconnect on status codes: UNAVAILABLE, INTERNAL, DEADLINE_EXCEEDED, UNAUTHENTICATED");
+        terminationLatch.await();
+    }
+
+    /**
+     * Stops the streaming subscription.
+     */
+    public void stop() {
+        logger.info("Stopping " + streamName + " streaming...");
+        running.set(false);
+    }
+
+    /**
+     * Starts streaming with selective reconnection logic.
+     * This only reconnects for specific status codes.
+     *
+     * @param observer The observer to receive events
+     */
+    private void startStreamingWithReconnect(StreamObserver<TResponse> observer) {
+        // Create a wrapper observer that handles reconnection
+        StreamObserver<TResponse> reconnectingObserver = new StreamObserver<TResponse>() {
+            @Override
+            public void onNext(TResponse response) {
+                observer.onNext(response);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                // Extract the gRPC status code
+                Status status = Status.fromThrowable(t);
+                Status.Code code = status.getCode();
+
+                // Handle authentication errors specially
+                if (code == Status.Code.UNAUTHENTICATED) {
+                    logger.info("Authentication error detected, forcing token refresh");
+                    if (credentials != null) {
+                        credentials.handleAuthenticationError();
+                    }
+                }
+
+                // Forward the error to the original observer
+                observer.onError(t);
+
+                // Attempt to reconnect only for specific status codes and if we're still running
+                if (running.get() && RETRYABLE_STATUS_CODES.contains(code)) {
+                    try {
+                        logger.info("Reconnecting after error (" + code + ") in " + reconnectDelaySeconds + " seconds...");
+                        Thread.sleep(reconnectDelaySeconds * 1000); // Wait before reconnecting
+
+                        // Subscribe again if we're still running
+                        if (running.get()) {
+                            logger.info("Resubscribing to " + streamName);
+                            startStreamingWithReconnect(observer);
+                        }
+                    } catch (InterruptedException e) {
+                        logger.log(Level.WARNING, "Reconnection interrupted for " + streamName, e);
+                        Thread.currentThread().interrupt();
+                    }
+                } else {
+                    logger.info("Not reconnecting for status code: " + code);
+                }
+            }
+
+            @Override
+            public void onCompleted() {
+                // Forward the completion event
+                observer.onCompleted();
+
+                // We don't reconnect on normal completion
+                logger.info("Stream completed normally by server, not reconnecting");
+            }
+        };
+
+        // Make the call with the reconnecting observer
+        try {
+            rpcMethod.call(request, reconnectingObserver);
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Error starting " + streamName + " stream", e);
+            // Trigger error handling through the observer
+            reconnectingObserver.onError(e);
+        }
+    }
+
+    /**
+     * Builder class for easier construction of StreamingClient instances.
+     */
+    public static class Builder<TRequest, TResponse> {
+        private StreamingRpcMethod<TRequest, TResponse> rpcMethod;
+        private TRequest request;
+        private StreamObserver<TResponse> observer;
+        private String streamName = "Generic Stream";
+        private int reconnectDelaySeconds = 5;
+        private JwtCredentials credentials;
+
+        public Builder<TRequest, TResponse> rpcMethod(StreamingRpcMethod<TRequest, TResponse> rpcMethod) {
+            this.rpcMethod = rpcMethod;
+            return this;
+        }
+
+        public Builder<TRequest, TResponse> request(TRequest request) {
+            this.request = request;
+            return this;
+        }
+
+        public Builder<TRequest, TResponse> observer(StreamObserver<TResponse> observer) {
+            this.observer = observer;
+            return this;
+        }
+
+        public Builder<TRequest, TResponse> streamName(String name) {
+            this.streamName = name;
+            return this;
+        }
+
+        public Builder<TRequest, TResponse> reconnectDelay(int seconds) {
+            this.reconnectDelaySeconds = seconds;
+            return this;
+        }
+
+        public Builder<TRequest, TResponse> credentials(JwtCredentials credentials) {
+            this.credentials = credentials;
+            return this;
+        }
+
+        public StreamingClient<TRequest, TResponse> build() {
+            if (rpcMethod == null) {
+                throw new IllegalArgumentException("rpcMethod is required");
+            }
+            if (request == null) {
+                throw new IllegalArgumentException("request is required");
+            }
+            if (observer == null) {
+                throw new IllegalArgumentException("observer is required");
+            }
+
+            return new StreamingClient<>(rpcMethod, request, observer, streamName, reconnectDelaySeconds, credentials);
+        }
+    }
+}
+

--- a/examples/java/src/main/java/com/example/streaming/StreamingRpcMethod.java
+++ b/examples/java/src/main/java/com/example/streaming/StreamingRpcMethod.java
@@ -1,0 +1,22 @@
+package com.example.streaming;
+
+import io.grpc.stub.StreamObserver;
+
+/**
+ * Functional interface for gRPC streaming RPC methods.
+ * This allows the generic streaming client to work with any streaming RPC.
+ *
+ * @param <TRequest> The request type for the streaming RPC
+ * @param <TResponse> The response type for the streaming RPC
+ */
+@FunctionalInterface
+public interface StreamingRpcMethod<TRequest, TResponse> {
+    /**
+     * Calls the streaming RPC method.
+     *
+     * @param request The request to send
+     * @param observer The observer to receive streaming responses
+     */
+    void call(TRequest request, StreamObserver<TResponse> observer);
+}
+


### PR DESCRIPTION
ChangeLog
======
Enhanced the existing gRPC client wrapper in Java
- Enable generic server-side streaming RPC invocation 
- Added illustrative examples on simple usage and concurrent subscriptions
- Simply README for better readability

Next Steps
======
- Add unary RPC retry functionalities