### PR TITLE
[BA-523] Refactor API Docs: Remove language-specific examples, use JSON request/response

### DIFF
--- a/docs/v1.0/resources/FleetManagement.md
+++ b/docs/v1.0/resources/FleetManagement.md
@@ -14,6 +14,16 @@ All specified fields are combined using an **AND** condition.
 |------|------|-------------|
 |`location_id`| `string`|An empty location_id return all robots assigned <br />to all locations created and owned by API key user.  |
 
+##### JSON Request Example
+=== "JSON"
+    ```js
+      {
+        "filter": {
+          "locationId": "location-123"
+        }
+      }
+    ```
+
 ### Response
 A response message has 2 fields: <br/>
 
@@ -22,134 +32,22 @@ A response message has 2 fields: <br/>
 |`total_robots`| `int32`| Total number of robots. |
 |`robot_ids`| List of `string` | This might not have all the robot IDs if there are too many.<br /> It will have all the robot IDs if the number of <br /> `robot_ids` is same as `total_robots`. |
 
+##### JSON Response Example
+=== "JSON"
+    ```js
+      {
+        "totalRobots": 5,
+        "robotIds": [
+          "pennybot-abc123",
+          "pennybot-def456",
+          "pennybot-ghi789",
+          "pennybot-jkl012",
+          "pennybot-mno345"
+        ]
+      }
+    ```
 
 ### Errors
 | ErrorCode  | Description |
 |------------|-------------|
 | `PERMISSION_DENIED` | Attempting to retrieve Robot IDs with a `location_id` you don't own. <br /> Tips: check the spelling of all `location_id` values.|
-
-### Examples
-=== "Go"
-    ```go
-    package main
-
-    import (
-      "context"
-      "fmt"
-      "log"
-      "time"
-
-      "google.golang.org/grpc"
-      "google.golang.org/grpc/metadata"
-
-      corepb "your_project_path/bearrobotics/api/v1/core"
-      servicespb "your_project_path/bearrobotics/api/v1/services"
-    )
-
-    func GetToken() (string, error) {
-      // Fetch your API key JWT and return it as a string.
-    }
-
-    func createChannelWithCredentialsRefresh() (*grpc.ClientConn, context.CancelFunc, error) {
-      // Create a secure connection with SSL credentials.
-    }
-
-    func listRobotIDs() {
-      token, err := GetToken()
-      if err != nil {
-        log.Fatalf("Failed to get token: %v", err)
-      }
-
-      conn, cancel, err := createChannelWithCredentialsRefresh()
-      if err != nil {
-        log.Fatalf("Failed to create channel: %v", err)
-      }
-      defer cancel()
-      defer conn.Close()
-
-      stub := servicespb.NewServicesClient(conn)
-
-      ctx, cancelCtx := context.WithTimeout(context.Background(), 5*time.Second)
-      defer cancelCtx()
-      ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
-
-      req := &corepb.ListRobotIDsRequest{
-        Filter: &corepb.RobotFilter{
-          LocationId:    "location-123",
-        },
-      }
-
-      resp, err := stub.ListRobotIDs(ctx, req)
-      if err != nil {
-        log.Fatalf("ListRobotIDs failed: %v", err)
-      }
-
-      fmt.Println("Robot IDs:", resp)
-    }
-
-    func main() {
-      listRobotIDs()
-    }
-    ```
-
-=== "Python gRPC"
-    ```python
-    import grpc
-    from bearrobotics.api.v1 import core_pb2
-    from bearrobotics.api.v1 import services_pb2_grpc
-
-    def get_token():
-        # Fetch your API key JWT
-        pass
-
-    def create_channel_with_credentials_refresh():
-        # Return a secure gRPC channel
-        pass
-
-    def list_robot_ids():
-        try:
-            token = get_token()
-            channel = create_channel_with_credentials_refresh()
-            stub = services_pb2_grpc.ServicesStub(channel)
-
-            request = core_pb2.ListRobotIDsRequest(
-                filter=core_pb2.RobotFilter(
-                    location_id="location-123",
-                )
-            )
-
-            metadata = [("authorization", f"Bearer {token}")]
-            response = stub.ListRobotIDs(request, metadata=metadata)
-            print("Robot IDs:", response)
-
-        except grpc.RpcError as e:
-            print(f"gRPC error: {e.code().name} - {e.details()}")
-        except Exception as ex:
-            print(f"Unexpected error: {type(ex).__name__} - {ex}")
-    ```
-
-=== "gRPCurl"
-    ```bash
-    grpcurl \
-      -proto bearrobotics/api/v1/services/cloud_api_service.proto \
-      -import-path protos \
-      -d '{
-        "filter": {
-          "locationId": "location-123",
-        }
-      }' \
-      api.bearrobotics.api:443 \
-      bearrobotics.api.v1.services.cloud.APIService.ListRobotIDs
-    ```
-
-=== "Protobuf"
-    ###### Refer to our [public protobuf repo](https://github.com/bearrobotics-public/cloud/tree/v1.0) for actual package names and full definitions.
-    ```proto
-    message RobotFilter {
-      string location_id = 1;
-    }
-
-    message ListRobotIDsRequest {
-      core.RobotFilter filter = 1;
-    }
-    ```

--- a/docs/v1.0/resources/Localization.md
+++ b/docs/v1.0/resources/Localization.md
@@ -18,134 +18,11 @@ The ID of the robot that the localization command is sent to.
 |[destination_id](../../v1.0/resources/LocationsAndMaps.md) | `string` | Unique identifier for the destination.|
 |[Pose](../../concepts/localization.md)| [`Pose`](../../v1.0/resources/Localization.md#pose) |`x_meters` *float* X-coordinate in meters within the map. <br/> `x_meters` *float* Y-coordinate in meters within the map. <br/> `heading_radians` *float* The heading of the robot in radians. Ranges from -π to π, where 0.0 points along the positive x-axis.|
 
-### Response
-
-*(No fields defined)* `{}` 
-
-### Errors
-| ErrorCode  | Description |
-|------------|-------------|
-|`FAILED_PRECONDITION`   |  While the robot is localizing, any subsequent requests <br /> to localize the robot will return a error until the process is completed.|
-
-### Examples
-=== "Go"
-    ```go
-    package main
-
-    import (
-      "context"
-      "fmt"
-      "log"
-      "time"
-
-      "google.golang.org/grpc"
-      "google.golang.org/grpc/metadata"
-
-      corepb "your_project_path/bearrobotics/api/v1/core"
-      servicespb "your_project_path/bearrobotics/api/v1/services"
-    )
-
-    func GetToken() (string, error) {
-      // Fetch JWT token
-    }
-
-    func createChannelWithCredentialsRefresh() (*grpc.ClientConn, context.CancelFunc, error) {
-      // Return a secure channel
-    }
-
-    func localizeRobotWithPose() {
-      token, err := GetToken()
-      if err != nil {
-        log.Fatalf("Token error: %v", err)
-      }
-
-      conn, cancel, err := createChannelWithCredentialsRefresh()
-      if err != nil {
-        log.Fatalf("Connection error: %v", err)
-      }
-      defer cancel()
-      defer conn.Close()
-
-      stub := servicespb.NewServicesClient(conn)
-
-      ctx, cancelCtx := context.WithTimeout(context.Background(), 5*time.Second)
-      defer cancelCtx()
-      ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
-
-      req := &corepb.LocalizeRobotRequest{
-        RobotId: "pennybot-aaa111",
-        Goal: &corepb.Goal{
-          Goal: &corepb.Goal_Pose{
-            Pose: &corepb.Pose{
-              XMeters:        1.5,
-              YMeters:        2.8,
-              HeadingRadians: -0.52,
-            },
-          },
-        },
-      }
-
-      _, err = stub.LocalizeRobot(ctx, req)
-      if err != nil {
-        log.Fatalf("LocalizeRobot failed: %v", err)
-      }
-
-      fmt.Println("Localization request sent.")
-    }
-
-    func main() {
-      localizeRobotWithPose()
-    }
-    ```
-
-=== "Python gRPC"
-    ```python
-    import grpc
-    from bearrobotics.api.v1 import core_pb2
-    from bearrobotics.api.v1 import services_pb2_grpc
-
-    def get_token():
-        # Return JWT token
-        pass
-
-    def create_channel_with_credentials_refresh():
-        # Return secure channel
-        pass
-
-    def localize_robot_with_pose():
-        try:
-            token = get_token()
-            channel = create_channel_with_credentials_refresh()
-            stub = services_pb2_grpc.ServicesStub(channel)
-
-            request = core_pb2.LocalizeRobotRequest(
-                robot_id="pennybot-111aaa",
-                goal=core_pb2.Goal(
-                    pose=core_pb2.Pose(
-                        x_meters=1.5,
-                        y_meters=2.8,
-                        heading_radians=-0.52
-                    )
-                )
-            )
-
-            metadata = [("authorization", f"Bearer {token}")]
-            stub.LocalizeRobot(request, metadata=metadata)
-            print("Localization request sent.")
-
-        except grpc.RpcError as e:
-            print(f"gRPC error: {e.code().name} - {e.details()}")
-        except Exception as ex:
-            print(f"Unexpected error: {type(ex).__name__} - {ex}")
-    ```
-
-=== "gRPCurl"
-    ```bash
-    grpcurl \
-      -proto bearrobotics/api/v1/services/cloud_api_service.proto \
-      -import-path protos \
-      -d '{
-        "robot_id": "pennybot-123123",
+##### JSON Request Example
+=== "JSON"
+    ```js
+      {
+        "robotId": "pennybot-123123",
         "goal": {
           "pose": {
             "xMeters": 1.5,
@@ -153,34 +30,23 @@ The ID of the robot that the localization command is sent to.
             "headingRadians": -0.52
           }
         }
-      }' \
-      api.bearrobotics.api:443 \
-      bearrobotics.api.v1.services.cloud.APIService.LocalizeRobot
-    ```
-
-=== "Protobuf"
-    ###### Refer to our [public protobuf repo](https://github.com/bearrobotics-public/cloud/tree/v1.0) for actual package names and full definitions.
-
-    ```proto
-    message Pose {
-      float x_meters = 1;
-      float y_meters = 2;
-      float heading_radians = 3;
-    }
-
-    message Goal {
-      oneof goal {
-        string destination_id = 1;
-        Pose pose = 2;
       }
-    }
-
-    message LocalizeRobotRequest {
-      string robot_id = 1;
-      core.Goal goal = 2;
-    }
     ```
 
+### Response
+
+*(No fields defined)* 
+
+##### JSON Response Example
+=== "JSON"
+    ```js
+      {}
+    ```
+
+### Errors
+| ErrorCode  | Description |
+|------------|-------------|
+|`FAILED_PRECONDITION`   |  While the robot is localizing, any subsequent requests <br /> to localize the robot will return a error until the process is completed.|
 
 -----------
 
@@ -190,6 +56,14 @@ A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#s
 ### Request
 ##### robot_id `string` `required`
 The ID of the robot that emergency stop subscription request is sent to.
+
+##### JSON Request Example
+=== "JSON"
+    ```js
+      {
+        "robotId": "pennybot-123123"
+      }
+    ```
 
 ### Response
 
@@ -207,13 +81,7 @@ The ID of the robot that emergency stop subscription request is sent to.
 | EMERGENCY_ENGAGED          | 1      | Triggers an emergency stop. <br/> Overrides and sets navigation-related velocity command to 0 to the motor.  |
 | EMERGENCY_DISENGAGED       | 2      | Wheels will resume acting upon software navigation commands.    |
 
-### Errors
-| ErrorCode  | Description |
-|------------|-------------|
-| `PERMISSION_DENIED` | Attempting to request status for `robot_id` you don't own. <br /> Tips: check the spelling of the `robot_id`.|
-
-### Examples
-##### Response
+##### JSON Response Example
 === "JSON"
     ```json
     {
@@ -227,31 +95,10 @@ The ID of the robot that emergency stop subscription request is sent to.
     }
     ```
 
-=== "Protobuf"
-    ```proto
-    message EventMetadata {
-      google.protobuf.Timestamp timestamp = 1;
-
-      int64 sequence_number = 2;
-    }
-
-    message EmergencyStopState {
-
-      enum Emergency {
-        EMERGENCY_UNKNOWN = 0;
-
-        EMERGENCY_ENGAGED = 1;
-
-        EMERGENCY_DISENGAGED = 2;
-      }
-      Emergency emergency = 1;
-    }
-
-    message SubscribeEmergencyStopStatusResponse {
-      core.EventMetadata metadata = 1;
-      core.EmergencyStopState e_stop_state = 2;
-    }
-    ```
+### Errors
+| ErrorCode  | Description |
+|------------|-------------|
+| `PERMISSION_DENIED` | Attempting to request status for `robot_id` you don't own. <br /> Tips: check the spelling of the `robot_id`.|
 
 ## SubscribeLocalizationStatus
 A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) endpoint to get the robot’s localization state. Upon subscription, the latest localization state is sent immediately. State updates are streamed while localization is active.
@@ -259,6 +106,14 @@ A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#s
 ### Request
 ##### robot_id `string` `required`
 The ID of the robot that subscription request is sent to.
+
+##### JSON Request Example
+=== "JSON"
+    ```js
+      {
+        "robotId": "pennybot-123123"
+      }
+    ```
 
 ### Response
 
@@ -277,13 +132,7 @@ The ID of the robot that subscription request is sent to.
 | STATE_SUCCEEDED          | 2      | Localization completed successfully.     |
 | STATE_LOCALIZING           | 3      | The robot is actively attempting to localize.  |
 
-### Errors
-| ErrorCode  | Description |
-|------------|-------------|
-| `PERMISSION_DENIED` | Attempting to request status for a `robot_id` you don't own. <br /> Tips: check the spelling of all `robot_id` values.|
-
-### Examples
-##### Response
+##### JSON Response Example
 === "JSON"
     ```json
     {
@@ -296,30 +145,10 @@ The ID of the robot that subscription request is sent to.
       }
     }
     ```
-
-=== "Protobuf"
-    ```proto
-    message LocalizationState {
-      enum State {
-        STATE_UNKNOWN = 0;
-        STATE_FAILED = 1;
-        STATE_SUCCEEDED = 2;
-        STATE_LOCALIZING = 3;
-      }
-      State state = 2;
-    }
-
-    message EventMetadata {
-      google.protobuf.Timestamp timestamp = 1;
-      int64 sequence_number = 2;
-    }
-
-    message SubscribeLocalizationStatusResponse {
-      core.EventMetadata metadata = 1;
-      core.LocalizationState localization_state = 2;
-    }
-    ```
-
+### Errors
+| ErrorCode  | Description |
+|------------|-------------|
+| `PERMISSION_DENIED` | Attempting to request status for a `robot_id` you don't own. <br /> Tips: check the spelling of all `robot_id` values.|
 
 -----------
 ## SubscribeRobotPose
@@ -338,6 +167,18 @@ A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#s
 |`robot_ids`| `RobotIDs`| Selects robots by their specific IDs. <br/> Example: `["pennybot-123abc", "pennybot-abc123"]` |
 |`location_id`|`string` |  Selects all robots at the specified location. |
 
+##### JSON Request Example
+=== "JSON"
+    ```js
+      {
+        "selector": {
+          "robot_ids": {
+            "ids": ["pennybot-abc123", "pennybot-123abc"]
+          }
+        }
+      }
+    ```
+
 ### Response
 ##### PoseWithMetadata
 
@@ -354,14 +195,7 @@ A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#s
 | `y_meters` | float | Y-coordinate in meters within the map. |
 | `heading_radians` | float | The heading of the robot in radians.<br>Ranges from -π to π, where 0.0 points along the positive x-axis. |
 
-
-### Errors
-| ErrorCode  | Description |
-|------------|-------------|
-| `PERMISSION_DENIED` | Attempting to request status for a `robot_id`  or `location_id` you don't own. <br /> Tip: check the spelling of all `robot_id` or `location_id` values.|
-
-### Examples
-##### Response
+##### JSON Response Example
 === "JSON"
     ```js
     {
@@ -392,26 +226,7 @@ A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#s
     }
     ```
 
-=== "Protobuf"
-    ```proto
-    message Pose {
-      float x_meters = 1;
-      float y_meters = 2;
-      float heading_radians = 3;
-    }
-
-    message PoseWithMetadata {
-      EventMetadata metadata = 1;
-      Pose pose = 2;
-    }
-
-    message EventMetadata {
-      google.protobuf.Timestamp timestamp = 1;
-      int64 sequence_number = 2;
-    }
-
-    message SubscribeRobotPoseResponse {
-      map<string, core.PoseWithMetadata> poses = 2;
-    }
-    ```
-
+### Errors
+| ErrorCode  | Description |
+|------------|-------------|
+| `PERMISSION_DENIED` | Attempting to request status for a `robot_id`  or `location_id` you don't own. <br /> Tip: check the spelling of all `robot_id` or `location_id` values.|

--- a/docs/v1.0/resources/LocationsAndMaps.md
+++ b/docs/v1.0/resources/LocationsAndMaps.md
@@ -11,6 +11,15 @@ The returned map includes annotations and destinations, which can be used in mis
 ##### robot_id `string` `required`
 The robot ID used to request the map currently loaded on the robot.
 
+
+##### JSON Request Example
+=== "JSON"
+    ```js
+      {
+        "robot_id": "pennybot-abc123"
+      }
+    ```
+
 ### Response
 
 ##### map `Map`
@@ -42,15 +51,7 @@ Destination represents a single point of interest on the map that a robot can na
 | `destination_id` | string | Unique identifier for the destination. |
 | `display_name` | string | Human-readable name for the destination. |
 
-### Errors
-
-| ErrorCode  | Description |
-|------------|-------------|
-| `NOT_FOUND`| The annotation (of the requested map) does not exist. |
-
-### Examples
-
-##### Response
+##### JSON Response Example
 === "JSON"
     ```js
        {
@@ -76,40 +77,8 @@ Destination represents a single point of interest on the map that a robot can na
         }
       }
     ```
+### Errors
 
-=== "Protobuf"
-    ###### Refer to our [public protobuf repo](https://github.com/bearrobotics-public/cloud/tree/v1.0) for actual package names and full definitions.
-    
-    ```proto
-    message Destination {
-      string destination_id = 1;
-
-      string display_name = 2;
-
-    }
-
-    message Annotation {
-
-      string annotation_id = 1;
-
-      string display_name = 2;
-
-      google.protobuf.Timestamp created_time = 3;
-
-      map<string, Destination> destinations = 4;
-    }
-
-    message Map {
-
-      string map_id = 1;
-
-      google.protobuf.Timestamp created_time = 2;
-
-      google.protobuf.Timestamp modified_time = 3;
-
-      string display_name = 4;
-
-      Annotation annotation = 5;
-    }
-    ```
-    
+| ErrorCode  | Description |
+|------------|-------------|
+| `NOT_FOUND`| The annotation (of the requested map) does not exist. |

--- a/docs/v1.0/resources/Mission.md
+++ b/docs/v1.0/resources/Mission.md
@@ -54,261 +54,52 @@ A mission that automatically selects the best available goal from the provided l
 |------------|-------------| ---|
 |[destination_id](../../v1.0/resources/LocationsAndMaps.md#destination) | `string` | Unique identifier for the destination.|
 
-**Refer to the [examples](#examples) for how to create and send a Mission.**
+##### JSON Request Example
+=== "JSON"
+    ```js
+      {
+        "robotId": "robot-001",
+        "mission": {
+          "baseMission": {
+            "navigateMission": {
+              "goal": {
+                "destinationId": "Main Kitchen"
+              }
+            }
+          }
+        }
+      }
+    ```
 
+-----------
 ### Response
 
 ##### **mission_id** `string`
 The ID of the mission created. 
 
+##### JSON Response Example
+=== "JSON"
+    ```js
+      {
+        "missionId": "mission-xyz-123"
+      }
+    ```
+
+-----------
 ### Errors
 | ErrorCode  | Description |
 |------------|-------------|
 |`FAILED_PRECONDITION`   |  The robot is already executing another mission. <br /> This command is valid if current mission is in [terminal state](#state-enum), <br /> e.g Cancelled, Succeeded, Failed. |
 
-
-### Examples
-=== "Go"
-    ```go
-    package main
-
-    import (
-      "context"
-      "fmt"
-      "log"
-      "time"
-
-      "google.golang.org/grpc"
-      "google.golang.org/grpc/metadata"
-
-      corepb "your_project_path/bearrobotics/api/v1/core"
-      servicespb "your_project_path/bearrobotics/api/v1/services"
-    )
-
-    func GetToken() (string, error) {
-      // Fetch your API key JWT and return it as a string.
-    }
-
-    func createChannelWithCredentialsRefresh() (*grpc.ClientConn, context.CancelFunc, error) {
-      // Create a secure connection with SSL credentials.
-    }
-
-    func createMissionWithDestination() {
-      token, err := GetToken()
-      if err != nil {
-        log.Fatalf("Failed to get token: %v", err)
-      }
-
-      conn, cancel, err := createChannelWithCredentialsRefresh()
-      if err != nil {
-        log.Fatalf("Failed to create channel: %v", err)
-      }
-      defer cancel()
-      defer conn.Close()
-
-      stub := servicespb.NewServicesClient(conn)
-
-      ctx, cancelCtx := context.WithTimeout(context.Background(), 5*time.Second)
-      defer cancelCtx()
-      ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
-
-      req := &corepb.CreateMissionRequest{
-        RobotId: "pennybot-123abc",
-        Mission: &corepb.Mission{
-          BaseMission: &corepb.BaseMission{
-            NavigateMission: &corepb.NavigateMission{
-              Goal: &corepb.Goal{
-                Goal: &corepb.Goal_DestinationId{
-                  DestinationId: "dest-001",
-                },
-              },
-            },
-          },
-        },
-      }
-
-      resp, err := stub.CreateMission(ctx, req)
-      if err != nil {
-        log.Printf("CreateMission (destination_id) failed: %v", err)
-        return
-      }
-
-      fmt.Println("CreateMission (destination_id) response:", resp)
-    }
-
-    func main() {
-      createMissionWithDestination()
-    }
-    ```
-
-=== "Python gRPC"
-    ```python
-    import grpc
-    from bearrobotics.api.v1 import core_pb2
-    from bearrobotics.api.v1 import services_pb2_grpc
-
-    def get_token():
-        # Fetch your API key JWT and return it as a string.
-        pass
-
-    def create_channel_with_credentials_refresh():
-        # Create a secure connection with SSL credentials.
-        pass
-
-    def create_mission_request_with_destination():
-        try:
-            token = get_token()
-            channel = create_channel_with_credentials_refresh()
-            stub = CloudAPIServiceStub(channel)
-
-            request = core_pb2.CreateMissionRequest(
-                robot_id="pennybot-123abc",
-                mission=core_pb2.Mission(
-                    base_mission=core_pb2.BaseMission(
-                        navigate_mission=core_pb2.NavigateMission(
-                            goal=core_pb2.Goal(
-                                destination_id="dest-001"
-                            )
-                        )
-                    )
-                )
-            )
-
-            response = stub.CreateMission(request)
-            print("CreateMission (destination) response:", response)
-
-        except grpc.RpcError as e:
-            print(f"gRPC error: {e.code().name} - {e.details()}")
-        except Exception as ex:
-            print(f"Unexpected error: {type(ex).__name__} - {ex}")
-    ```
-=== "Python HTTP/POST"
-    ```python
-    import requests
-
-    BEAR_API_BASE_URL = "https://api.bearrobotics.api"
-    ACCESS_TOKEN = "YOUR_JWT_BEARER_TOKEN"
-
-    def bear_api_create_mission(robot_id: str, destination_id: str) -> requests.Response:
-        """
-        Creates a mission for a robot using the Bear API via HTTP POST.
-
-        Args:
-            robot_id: The unique ID of the robot to assign the mission to.
-            destination_id: The goal destination ID to navigate to.
-
-        Returns:
-            A `requests.Response` object from the Bear API.
-        """
-        url = f"{BEAR_API_BASE_URL}/v1/mission/create"
-        payload = {
-            "robot_id": robot_id,
-            "mission": {
-                "baseMission": {
-                    "navigateMission": {
-                        "goal": {
-                            "destinationId": destination_id
-                        }
-                    }
-                }
-            }
-        }
-        headers = {
-            "Authorization": f"Bearer {ACCESS_TOKEN}",
-            "Content-Type": "application/json"
-        }
-
-        return requests.post(url, json=payload, headers=headers)
-
-    def main():
-        robot_id = "pennybot-abc123"
-        destination_id = "kitchen-42"
-
-        response = bear_api_create_mission(robot_id, destination_id)
-
-        if response.ok:
-            print("Mission created:", response.json())
-        else:
-            print("Bear API error:", response.status_code, response.text)
-
-    if __name__ == "__main__":
-        main()
-
-    ```
-=== "gRPCurl"
-    ```bash
-    grpcurl \
-      -proto bearrobotics/api/v1/services/cloud_api_service.proto \
-      -import-path protos \
-      -d '{
-        "robot_id": "pennybot-123abc",
-        "mission": {
-          "baseMission": {
-            "navigateMission": {
-              "goal": {
-                "destinationId": "dest-001"
-              }
-            }
-          }
-        }
-      }' \
-      api-test.bearrobotics.api:443 bearrobotics.api.v1.services.cloud.APIService.CreateMission
-
-    ```
-
-=== "Protobuf"
-    ###### Refer to our [public protobuf repo](https://github.com/bearrobotics-public/cloud/tree/v1.0) for actual package names and full definitions.
-    ```proto
-
-    message Goal {
-      oneof goal {
-        string destination_id = 1;
-      }
-    }
-
-    message NavigateMission {
-      Goal goal = 1;
-    }
-
-    message NavigateAutoMission {
-      repeated Goal goals = 1;
-    }
-    
-    message BaseMission {
-      oneof mission {
-        NavigateMission navigate_mission = 1;
-        NavigateAutoMission navigate_auto_mission = 2;
-      }
-    }
-
-    message Mission {
-      oneof mission {
-        BaseMission base_mission = 1;
-        servi.Mission servi_mission = 2;
-        carti.Mission carti_mission = 3;
-      }
-    }
-
-    message CreateMissionRequest {
-      string robot_id = 1;
-      core.Mission mission = 2;
-    }
-
-    message CreateMissionResponse {
-      string mission_id = 1;
-    }
-    ```
-
------------
 ## AppendMission 
 Appends a mission to the end of the [mission queue](../../concepts/mission.md#mission-queue). <br/>
 Use this when a mission is currently running; otherwise, prefer [CreateMission](#createmission). <br/>
 Missions are executed in the order they are appended.
 
-### Request / Response/ Examples
+### JSON Request / Response Example
 !!! note ""
     AppendMission request and response message types are the same as [CreateMission](#createmission).  
-    See CreateMission [Examples](#examples).
+    See [CreateMission JSON Examples](#json-request-example).
 
 ### Errors
 | ErrorCode  | Description |
@@ -346,12 +137,28 @@ The ID of the robot that will receive this command.
 | COMMAND_RESUME         | 3      | Resume a paused mission.                         |
 | COMMAND_FINISH         | 4      | Mark the mission as completed.                   |
 
-**Refer to the [examples](#examples_1) for how to create and send a MissionCommand.**
+##### JSON Request Example
+=== "JSON"
+    ```js
+      {
+        "robot_id": "pennybot-abc123",
+        "mission_command": {
+          "mission_id": "f842c8ac-62de-412e-90fb-bf37022db2f4",
+          "command": "COMMAND_PAUSE"
+        }
+      }
+    ```
 
 -----------
 ### Response
 
-*(No fields defined)* `{}` 
+*(No fields defined)*
+
+##### JSON Response Example
+=== "JSON"
+    ```js
+      {}
+    ```
 
 -----------
 ### Errors
@@ -359,199 +166,6 @@ The ID of the robot that will receive this command.
 |------------|-------------|
 | `NOT_FOUND` | The robot is NOT on the mission specified in the request. |
 | `INVALID_ARGUMENT`| The command is invalid for the robot's current state. <br /> For example, mission in [terminal state](#state-enum) (Cancelled, Succeeded, Failed) can't be updated. |
-
------------
-### Examples
-=== "Go"
-    ```go
-    package main
-
-    import (
-      "context"
-      "fmt"
-      "log"
-      "time"
-
-      "google.golang.org/grpc"
-      "google.golang.org/grpc/metadata"
-
-      corepb "your_project_path/bearrobotics/api/v1/core"
-      servicespb "your_project_path/bearrobotics/api/v1/services"
-    )
-
-    func GetToken() (string, error) {
-      // Fetch your API key JWT and return it as a string.
-    }
-
-    func createChannelWithCredentialsRefresh() (*grpc.ClientConn, context.CancelFunc, error) {
-      // Create a secure connection with SSL credentials.
-    }
-
-    func updateMissionCommand() {
-      token, err := GetToken()
-      if err != nil {
-        log.Fatalf("Failed to get token: %v", err)
-      }
-
-      conn, cancel, err := createChannelWithCredentialsRefresh()
-      if err != nil {
-        log.Fatalf("Failed to create channel: %v", err)
-      }
-      defer cancel()
-      defer conn.Close()
-
-      stub := servicespb.NewServicesClient(conn)
-
-      ctx, cancelCtx := context.WithTimeout(context.Background(), 5*time.Second)
-      defer cancelCtx()
-      ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
-
-      req := &corepb.UpdateMissionRequest{
-        RobotId: "pennybot-123abc",
-        MissionCommand: &corepb.MissionCommand{
-          MissionId: "d6637a14-5f6b-43f6-bd86-cc1871a8322e",
-          Command:   corepb.MissionCommand_COMMAND_PAUSE,
-        },
-      }
-
-      _, err = stub.UpdateMission(ctx, req)
-      if err != nil {
-        log.Printf("UpdateMission failed: %v", err)
-        return
-      }
-
-      fmt.Println("Mission command sent successfully.")
-    }
-
-    func main() {
-      updateMissionCommand()
-    }
-    ```
-
-=== "Python gRPC"
-    ```python
-    import grpc
-    from bearrobotics.api.v1 import core_pb2
-    from bearrobotics.api.v1 import services_pb2_grpc
-
-    def get_token():
-        # Fetch your API key JWT and return it as a string.
-        pass
-
-    def create_channel_with_credentials_refresh():
-        # Create a secure gRPC channel with SSL credentials.
-        pass
-
-    def send_mission_command():
-        try:
-            token = get_token()
-            channel = create_channel_with_credentials_refresh()
-            stub = services_pb2_grpc.ServicesStub(channel)
-
-            request = core_pb2.UpdateMissionRequest(
-                robot_id="pennybot-123abc",
-                mission_command=core_pb2.MissionCommand(
-                    mission_id="d6637a14-5f6b-43f6-bd86-cc1871a8322e",
-                    command=core_pb2.MissionCommand.COMMAND_PAUSE
-                )
-            )
-
-            metadata = [("authorization", f"Bearer {token}")]
-            response = stub.UpdateMission(request, metadata=metadata)
-            print("Mission command response:", response)
-
-        except grpc.RpcError as e:
-            print(f"gRPC error: {e.code().name} - {e.details()}")
-        except Exception as ex:
-            print(f"Unexpected error: {type(ex).__name__} - {ex}")
-    ```
-=== "Python HTTP/POST"
-    ```python
-    import requests
-
-    API_BASE_URL = "https://api.bearrobotics.api"
-    ACCESS_TOKEN = "YOUR_JWT_BEARER_TOKEN"
-
-    def update_mission(robot_id: str, mission_id: str, command: str) -> requests.Response:
-        """
-        Sends a mission update command via HTTP POST to the Bear API.
-
-        Args:
-            robot_id: The robot's unique identifier.
-            mission_id: The mission UUID to update.
-            command: The command to send (e.g., "COMMAND_PAUSE", "COMMAND_CANCEL").
-
-        Returns:
-            A `requests.Response` object.
-        """
-        url = f"{API_BASE_URL}/v1/mission/update"
-        payload = {
-            "robot_id": robot_id,
-            "mission_command": {
-                "mission_id": mission_id,
-                "command": command
-            }
-        }
-        headers = {
-            "Authorization": f"Bearer {ACCESS_TOKEN}",
-            "Content-Type": "application/json"
-        }
-
-        return requests.post(url, json=payload, headers=headers)
-
-    def main():
-        robot_id = "pennybot-abc123"
-        mission_id = "f842c8ac-62de-412e-90fb-bf37022db2f4"
-        command = "COMMAND_PAUSE"
-
-        response = update_mission(robot_id, mission_id, command)
-
-        if response.ok:
-            print("Mission update sent successfully.")
-        else:
-            print("Error:", response.status_code, response.text)
-
-    if __name__ == "__main__":
-        main()
-    ```
-=== "gRPCurl"
-    ```bash
-    grpcurl \
-      -proto bearrobotics/api/v1/services/cloud_api_service.proto \
-      -import-path protos \
-      -d '{
-        "robot_id": "pennybot-123abc",
-        "mission_command": {
-          "mission_id": "d6637a14-5f6b-43f6-bd86-cc1871a8322e",
-          "command": "COMMAND_PAUSE"
-        }
-      }' \
-      api-test.bearrobotics.api:443 bearrobotics.api.v1.services.cloud.APIService.UpdateMission
-    ```
-
-=== "Protobuf"
-    ```proto
-    message MissionCommand {
-      string mission_id = 1;
-
-      enum Command {
-        COMMAND_UNKNOWN = 0;
-        COMMAND_CANCEL = 1;
-        COMMAND_PAUSE = 2;
-        COMMAND_RESUME = 3;
-        COMMAND_FINISH = 4;
-      }
-
-      Command command = 2;
-    }
-
-    message UpdateMissionRequest {
-      string robot_id = 1;
-      core.MissionCommand mission_command = 2;
-    }
-
-    message UpdateMissionResponse {}
-    ```
 
 -----------
 ## SubscribeMissionStatus 
@@ -567,8 +181,17 @@ A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#s
 |`robot_ids`| `RobotIDs`| Selects robots by their specific IDs. <br/> Example: `["pennybot-123abc", "pennybot-abc123"]` |
 |`location_id`|`string` |  Selects all robots at the specified location. |
 
-**Refer to the [examples](#examples_2) for how to send a SubscribeMissionStatus request.**
-
+##### JSON Request Example
+=== "JSON"
+    ```js
+      {
+        "selector": {
+          "robot_ids": {
+            "ids": ["pennybot-abc123", "pennybot-123abc"]
+          }
+        }
+      }
+    ```
 
 ### Response
 This endpoint returns a stream of messages in response. <br/>
@@ -617,167 +240,7 @@ The robotID the message is associated with.
 | STATUS_UNKNOWN         | 0      | Default value. It means `status` field is not returned. |
 | STATUS_NAVIGATING      | 1      | The robot is currently navigating to its target.|
 
-
-### Errors
-
-| ErrorCode  | Description |
-|------------|-------------|
-| `PERMISSION_DENIED` | Attempting to request status for a `robot_id` or `location_id` you don't own. <br /> Tip: check the spelling of all `robot_id` or `location_id` values.|
-| `INVALID_ARGUMENT`| One or more request parameters are malformed or logically incorrect. <br /> Example: Using an invalid robot ID format. |
-
-### Examples
-##### Request
-
-=== "Go"
-    ```go
-    package main
-
-    import (
-      "context"
-      "fmt"
-      "io"
-      "log"
-      "time"
-
-      "google.golang.org/grpc"
-      "google.golang.org/grpc/metadata"
-
-      corepb "your_project_path/bearrobotics/api/v1/core"
-      servicespb "your_project_path/bearrobotics/api/v1/services"
-    )
-
-    func GetToken() (string, error) {
-      // Fetch your API key JWT.
-    }
-
-    func createChannelWithCredentialsRefresh() (*grpc.ClientConn, context.CancelFunc, error) {
-      // Create a secure gRPC channel.
-    }
-
-    func subscribeMissionStatus() {
-      token, err := GetToken()
-      if err != nil {
-        log.Fatalf("Failed to get token: %v", err)
-      }
-
-      conn, cancel, err := createChannelWithCredentialsRefresh()
-      if err != nil {
-        log.Fatalf("Failed to create channel: %v", err)
-      }
-      defer cancel()
-      defer conn.Close()
-
-      stub := servicespb.NewServicesClient(conn)
-
-      ctx, cancelCtx := context.WithTimeout(context.Background(), 60*time.Second)
-      defer cancelCtx()
-      ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
-
-      stream, err := stub.SubscribeMissionStatus(ctx, &corepb.SubscribeMissionStatusRequest{
-        Selector: &corepb.RobotSelector{
-          TargetId: &corepb.RobotSelector_RobotIds{
-            RobotIds: &corepb.RobotSelector_RobotIDs{
-              Ids: []string{"pennybot-123abc", "pennybot-abc123"},
-            },
-          },
-        },
-      })
-      if err != nil {
-        log.Fatalf("Failed to subscribe: %v", err)
-      }
-
-      for {
-        resp, err := stream.Recv()
-        if err == io.EOF {
-          break
-        }
-        if err != nil {
-          log.Printf("Stream error: %v", err)
-          break
-        }
-        fmt.Println("Mission status update:", resp)
-      }
-    }
-
-    func main() {
-      subscribeMissionStatus()
-    }
-    ```
-
-=== "Python gRPC Streaming"
-    ```python
-    import grpc
-    from bearrobotics.api.v1 import core_pb2
-    from bearrobotics.api.v1 import services_pb2_grpc
-
-    def get_token():
-        # Return your JWT auth token.
-        pass
-
-    def create_channel_with_credentials_refresh():
-        # Return a secure gRPC channel.
-        pass
-
-    def subscribe_mission_status():
-        try:
-            token = get_token()
-            channel = create_channel_with_credentials_refresh()
-            stub = services_pb2_grpc.ServicesStub(channel)
-
-            request = core_pb2.SubscribeMissionStatusRequest(
-                selector=core_pb2.RobotSelector(
-                    robot_ids=core_pb2.RobotSelector.RobotIDs(
-                        ids=["pennybot-123abc", "pennybot-abc123"]
-                    )
-                )
-            )
-
-            metadata = [("authorization", f"Bearer {token}")]
-            stream = stub.SubscribeMissionStatus(request, metadata=metadata)
-
-            for response in stream:
-                print("Mission status update:", response)
-
-        except grpc.RpcError as e:
-            print(f"gRPC error: {e.code().name} - {e.details()}")
-        except Exception as ex:
-            print(f"Unexpected error: {type(ex).__name__} - {ex}")
-    ```
-
-=== "gRPCurl"
-    ```bash
-    grpcurl \
-      -proto bearrobotics/api/v1/services/cloud_api_service.proto \
-      -import-path protos \
-      -d '{
-        "selector": {
-          "robotIds": {
-            "ids": ["pennybot-123abc", "pennybot-abc123"]
-          }
-        }
-      }' \
-      api.bearrobotics.api:443 \
-      bearrobotics.api.v1.services.cloud.APIService.SubscribeMissionStatus
-    ```
-=== "Protobuf"
-    ```proto
-    message RobotSelector {
-      message RobotIDs {
-        repeated string ids = 1;
-      }
-
-      oneof target_id {
-        RobotIDs robot_ids = 1;
-        string location_id = 2;
-      }
-    }
-
-    message SubscribeMissionStatusRequest {
-      core.RobotSelector selector = 1;
-    }
-    ```
-
-##### Response
+##### JSON Response Example
 === "JSON" 
     ```js
     {
@@ -809,80 +272,14 @@ The robotID the message is associated with.
         }
       }
     }
-
     ```
 
-=== "Protobuf"
-    ```proto
-    message BaseFeedback {
+### Errors
 
-    enum Status {
-      STATUS_UNKNOWN = 0;
-
-      STATUS_NAVIGATING = 1;
-    }
-      Status status = 1;
-    }
-
-    message MissionState {
-      string mission_id = 1;
-
-      enum State {
-        STATE_UNKNOWN = 0;
-
-        STATE_DEFAULT = 1;
-
-        STATE_RUNNING = 2;
-
-        STATE_PAUSED = 3;
-
-        STATE_CANCELED = 4;
-
-        STATE_SUCCEEDED = 5;
-
-        STATE_FAILED = 6;
-      }
-      State state = 2;
-
-      repeated Goal goals = 3;
-
-      int32 current_goal_index = 4;
-
-      message MissionFeedback {
-        oneof feedback {
-          BaseFeedback base_feedback = 1;
-        }
-      }
-
-      MissionFeedback mission_feedback = 5;
-    }
-
-    message Pose {
-      float x_meters = 1;
-      float y_meters = 2;
-      float heading_radians = 3;
-    }
-
-    message Goal {
-      oneof goal {
-        string destination_id = 1;
-        Pose pose = 2;
-      }
-    }
-
-    message SubscribeMissionStatusResponse {
-      core.EventMetadata metadata = 1;
-      string robot_id = 2;
-      core.MissionState mission_state = 3; 
-    }
-
-    message EventMetadata {
-      
-      google.protobuf.Timestamp timestamp = 1;
-
-      int64 sequence_number = 2;
-    }
-    ```
+| ErrorCode  | Description |
+|------------|-------------|
+| `PERMISSION_DENIED` | Attempting to request status for a `robot_id` or `location_id` you don't own. <br /> Tip: check the spelling of all `robot_id` or `location_id` values.|
+| `INVALID_ARGUMENT`| One or more request parameters are malformed or logically incorrect. <br /> Example: Using an invalid robot ID format. |
     
 -----------
 ## ChargeRobot
@@ -897,9 +294,25 @@ You can use [`SubscribeBatteryStatus`](RobotStatus.md#subscribebatterystatus) to
 ##### robot_id `string` `required`
 The ID of the robot that will receive this command.
 
+##### JSON Reqeuest Example
+=== "JSON" 
+    ```js
+    {
+      "robot_id": "pennybot-abc123"
+    }
+    ```
+
 ### Response
 ##### **mission_id** `string`
 The ID of the mission created. Since this command is a special type of mission, its execution state is also avaiable in response messages from [`SubscribeMissionStatus`](#subscribemissionstatus). 
+
+##### JSON Response Example
+=== "JSON" 
+    ```js
+    {
+      "mission_id": "mission-xyz-001"
+    }
+    ```
 
 ### Errors
 

--- a/docs/v1.0/resources/RobotStatus.md
+++ b/docs/v1.0/resources/RobotStatus.md
@@ -13,6 +13,18 @@ A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#s
 |`robot_ids`| `RobotIDs`| Selects robots by their specific IDs. <br/> Example: `["pennybot-123abc", "pennybot-abc123"]` |
 |`location_id`|`string` |  Selects all robots at the specified location. |
 
+##### JSON Request Example
+=== "JSON"
+    ```js
+      {
+        "selector": {
+          "robot_ids": {
+            "ids": ["pennybot-abc123", "pennybot-123abc"]
+          }
+        }
+      }
+    ```
+
 ### Response
 
 ##### metadata `EventMetadata`
@@ -50,12 +62,7 @@ Represents the state of the robot's battery system.
 | CHARGE_METHOD_WIRED          | 2      | Charging via a wired connection.     |
 | CHARGE_METHOD_CONTACT           | 3      | Charging via contact-based interface (e.g., docking station).|
 
-### Errors
-| ErrorCode  | Description |
-|------------|-------------|
-| `PERMISSION_DENIED` | Attempting to request status for a `robot_id` or `location_id` you don't own. <br /> Tip: check the spelling of all `robot_id` or `location_id` values.|
-
-### Examples
+##### JSON Response Examples
 === "JSON"
     ```json
     {
@@ -84,40 +91,10 @@ Represents the state of the robot's battery system.
     }
     ```
 
-=== "Protobuf"
-    ###### Refer to our [public protobuf repo](https://github.com/bearrobotics-public/cloud/tree/v1.0) for actual package names and full definitions.
-    ```proto
-    message BatteryState {
-      int32 charge_percent = 1;
-
-      enum State {
-        STATE_UNKNOWN = 0;
-        STATE_CHARGING = 1;
-        STATE_DISCHARGING = 2;
-        STATE_FULL = 3;
-      }
-      State state = 2;
-
-      enum ChargeMethod {
-        CHARGE_METHOD_UNKNOWN = 0;
-        CHARGE_METHOD_NONE = 1;
-        CHARGE_METHOD_WIRED = 2;
-        CHARGE_METHOD_CONTACT = 3;
-      }
-      ChargeMethod charge_method = 3;
-    }
-
-    message EventMetadata {
-      google.protobuf.Timestamp timestamp = 1;
-      int64 sequence_number = 2;
-    }
-
-    message SubscribeBatteryStatusResponse {
-      core.EventMetadata metadata = 1;
-      string robot_id = 2;
-      core.BatteryState battery_state = 3;
-    }
-    ```
+### Errors
+| ErrorCode  | Description |
+|------------|-------------|
+| `PERMISSION_DENIED` | Attempting to request status for a `robot_id` or `location_id` you don't own. <br /> Tip: check the spelling of all `robot_id` or `location_id` values.|
 
 -----------
 ## SubscribeRobotStatus
@@ -133,6 +110,17 @@ A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#s
 |`robot_ids`| `RobotIDs`| Selects robots by their specific IDs. <br/> Example: `["pennybot-123abc", "pennybot-abc123"]` |
 |`location_id`|`string` |  Selects all robots at the specified location. |
 
+##### JSON Request Example
+=== "JSON"
+    ```js
+      {
+        "selector": {
+          "robot_ids": {
+            "ids": ["pennybot-abc123", "pennybot-123abc"]
+          }
+        }
+      }
+    ```
 ### Response
 ##### metadata `EventMetadata`
 
@@ -153,12 +141,7 @@ Represents the online connection state between the cloud and the robot.
 | STATE_CONNECTED          | 1      | The robot is connected to Bear cloud services. |
 | STATE_DISCONNECTED          | 2      | The robot is offline or unreachable from the cloud.   |
 
-### Errors
-| ErrorCode  | Description |
-|------------|-------------|
-| `PERMISSION_DENIED` | Attempting to request status for a `robot_id` or `location_id` you don't own. <br /> Tip: check the spelling of all `robot_id` or `location_id` values.|
-
-### Examples
+##### JSON Response Example
 
 === "JSON"
     ```json
@@ -188,30 +171,7 @@ Represents the online connection state between the cloud and the robot.
     }
     ```
 
-=== "Protobuf"
-    ```proto
-    message RobotConnection {
-      enum State {
-        STATE_UNKNOWN = 0;
-        STATE_CONNECTED = 1;
-        STATE_DISCONNECTED = 2;
-      }
-      State state = 1;
-    }
-
-    message RobotState {
-      RobotConnection connection = 1;
-    }
-
-    message EventMetadata {
-      google.protobuf.Timestamp timestamp = 1;
-      int64 sequence_number = 2;
-    }
-
-    message SubscribeRobotStatusResponse {
-      core.EventMetadata metadata = 1;
-      string robot_id = 2;
-      core.RobotState robot_states = 3;
-    }
-    ```
-
+### Errors
+| ErrorCode  | Description |
+|------------|-------------|
+| `PERMISSION_DENIED` | Attempting to request status for a `robot_id` or `location_id` you don't own. <br /> Tip: check the spelling of all `robot_id` or `location_id` values.|


### PR DESCRIPTION
### Summary
Removed Go / Python / gRPCurl / Protobuf example blocks from all relevant endpoints

### What's Added

JSON Request / Response 
        UpdateMission
        SubscribeMissionStatus
        ChargeRobot
        AppendMission
        CreateMission (Carti / Servi variants)
        ListRobotIDs
        LocalizeRobot
        SubscribeTrayStatuses
        And others
