### PR TITLE
Remove keepalive config from examples

### DIFF
--- a/examples/java/src/main/java/com/example/BearRoboticsClient.java
+++ b/examples/java/src/main/java/com/example/BearRoboticsClient.java
@@ -64,8 +64,6 @@ public class BearRoboticsClient {
         // Build the channel with TLS and keep-alive options for long-running connections
         channel = ManagedChannelBuilder.forAddress(host, port)
                 .useTransportSecurity() // Use TLS for secure connection
-                .keepAliveTime(30, TimeUnit.SECONDS) // Send keepalive ping every 30 seconds
-                .keepAliveTimeout(10, TimeUnit.SECONDS) // Wait 10 seconds for ping ack before considering connection dead
                 .build();
 
         // Create the stubs with authentication

--- a/examples/python/main.py
+++ b/examples/python/main.py
@@ -31,7 +31,7 @@ def main():
         return 1
 
     robot_id = sys.argv[1]
-    
+
     if len(sys.argv) > 2:
         mode = sys.argv[2]
     else:
@@ -45,10 +45,6 @@ def main():
     channel = grpc.secure_channel(
         f"{host}:{port}",
         grpc.ssl_channel_credentials(),
-        options=[
-            ("grpc.keepalive_time_ms", 30000),
-            ("grpc.keepalive_timeout_ms", 10000),
-        ]
     )
     stub = APIServiceStub(channel)
 


### PR DESCRIPTION
ChangeLog
======
Removed the keepalive configuration to adhere to defaults (no keepalive), which results in the following behavioral changes:
- Python/Java: Since the client will not ping the server to diagnose server status, Now the retries won't be used up on intermittent network issues. 
- Python: There was a bug in gRPC Python where failing a certain number of ping checks will make the client connection in an unrecoverable state, which was resolvable by adding a nil callback to `channel.subscribe`. Removing the keepalive config also resolves this issue. 
