### PR TITLE
Enhanced Documentation for Streaming RPCs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,29 @@ sequenceDiagram
 ```
 ## Streaming RPCs
 
-[Server-side streaming RPCs](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) are used for receiving continuous updates, either event-based (e.g., mission status) or frequency-based (e.g., robot pose).
+[Server-side streaming RPCs](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) are used for receiving continuous updates. Streaming RPCs operate in one of the following modes depending on the nature of the data:
+
+- <a id="frequency-based"></a>**Frequency-based** streams deliver updates at a fixed cadence (e.g., ~10Hz),
+  regardless of whether the underlying value has changed. Delivery is
+  best-effort — individual updates may occasionally be dropped, but a fresh
+  one follows shortly after.
+
+    *Example: `SubscribeRobotPose` streams position estimates at ~10Hz. A single
+    dropped update has minimal impact since the next one arrives within
+    milliseconds.*
+
+- <a id="hybrid"></a>**Hybrid** streams combine both modes — updates are delivered at a minimum
+  fixed cadence, with additional updates sent whenever a meaningful state change
+  occurs between intervals.
+
+    *Example: `SubscribeRobotStatus` reports pose at a base rate of 1Hz, with
+    additional updates whenever other statuses change.*
+
+- <a id="event-based"></a>**Event-based** streams deliver updates only when a meaningful state change
+  occurs.
+
+    *Example: `SubscribeMissionStatus` notifies you each time a mission
+    transitions between states (e.g., from `EXECUTING` to `SUCCEEDED`).*
 
 !!! note
 
@@ -89,4 +111,17 @@ For server streaming RPCs, all responses include metadata containing a timestamp
 - **Sequence Number**: The sequence number is guaranteed to be incremental and can be used to detect duplicate responses. Note that the sequence number may reset to 0 at any time, though this should be rare (e.g., only during a service or robot restart).
 
 If strict detection of response duplication is desired, both the sequence number and timestamp should be used together. 
+
+### <a id="consolidated-vs-individual"></a>SubscribeRobotStatus vs. individual endpoints
+
+`SubscribeRobotStatus` provides a consolidated view of all robot state
+in a single stream — including connection, battery, emergency stop,
+mission, pose, and error codes. Use it when you need a general overview
+of the robot (e.g., for a monitoring dashboard) with minimal subscription
+management.
+
+Use individual endpoints (e.g., `SubscribeRobotPose`,
+`SubscribeBatteryStatus`) when you need higher update frequency or only
+a specific subset of data. For example, `SubscribeRobotPose` delivers
+pose at ~10Hz compared to 1Hz in `SubscribeRobotStatus`.
 

--- a/docs/v1.0/resources/Localization.md
+++ b/docs/v1.0/resources/Localization.md
@@ -51,6 +51,8 @@ The ID of the robot that the localization command is sent to.
 -----------
 
 ## SubscribeEmergencyStopStatus
+Streaming mode: [`event`](../../index.md#event-based)
+
 A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) endpoint to Subscribe to the software emergency stop state. Upon subscription, the latest emergency stop state is sent immediately. State updates are streamed whenever the emergency stop state changes.
 
 ### Request
@@ -101,6 +103,8 @@ The ID of the robot that emergency stop subscription request is sent to.
 | `PERMISSION_DENIED` | Attempting to request status for `robot_id` you don't own. <br /> Tips: check the spelling of the `robot_id`.|
 
 ## SubscribeLocalizationStatus
+Streaming mode: [`event`](../../index.md#event-based)
+
 A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) endpoint to get the robot’s localization state. Upon subscription, the latest localization state is sent immediately. State updates are streamed while localization is active.
 
 ### Request
@@ -152,6 +156,8 @@ The ID of the robot that subscription request is sent to.
 
 -----------
 ## SubscribeRobotPose
+Streaming mode: [`frequency`](../../index.md#frequency-based)
+
 A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) endpoint to subscribe to the robot's pose estimates at a regular frequency. (~10Hz) Use this to track the robot's position in real time.
 
 ### Request

--- a/docs/v1.0/resources/Mission.md
+++ b/docs/v1.0/resources/Mission.md
@@ -177,6 +177,8 @@ The ID of the robot that will receive this command.
 
 -----------
 ## SubscribeMissionStatus 
+Streaming mode: [`event`](../../index.md#event-based)
+
 A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) endpoint to get updates on the robot's mission state. Upon subscription, the latest known mission state is sent immediately. Subsequent updates are streamed as the state changes. 
 
 ### Request

--- a/docs/v1.0/resources/RobotStatus.md
+++ b/docs/v1.0/resources/RobotStatus.md
@@ -1,6 +1,8 @@
 These are streaming endpoints that provide real-time updates on robot health, including battery levels, charging state, and connectivity.
 
 ## SubscribeBatteryStatus
+Streaming mode: [`event`](../../index.md#event-based)
+
 A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) endpoint to get battery state updates for the robot. Upon subscription, the latest battery state is sent immediately. Updates are streamed whenever the state changes.
 
 ### Request
@@ -98,6 +100,8 @@ Represents the state of the robot's battery system.
 
 -----------
 ## SubscribeRobotStatus
+Streaming mode: [`hybrid`](../../index.md#hybrid) · [When to use this vs. individual endpoints](../../index.md#consolidated-vs-individual)
+
 A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) endpoint to get the robot's connectivity and operational state. Upon subscription, the latest battery state is sent immediately. Updates are streamed as the robot's state changes.
 
 ### Request

--- a/docs/v1.0/resources/Servi.md
+++ b/docs/v1.0/resources/Servi.md
@@ -115,6 +115,8 @@ The ID of the mission created.
 
 -----------
 ## SubscribeTrayStatuses
+Streaming mode: [`event`](../../index.md#event-based)
+
 Subscribes to the robot’s tray status updates. <br />
 Upon subscription, the latest known tray states are sent immediately. Updates are streamed when any tray state changes.
 

--- a/docs/v1.1/resources/Carti.md
+++ b/docs/v1.1/resources/Carti.md
@@ -172,6 +172,8 @@ List of available conveyor indexes for this robot.
 
 -----------
 ## SubscribeConveyorStatus
+Streaming mode: [`event`](../../index.md#event-based)
+
 A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) endpoint to get conveyor status updates for the robot. Upon subscription, the latest known conveyor states are sent immediately. Updates are streamed when any conveyor state changes.
 
 ### Request

--- a/docs/v1.1/resources/LocalizationAndNavigation.md
+++ b/docs/v1.1/resources/LocalizationAndNavigation.md
@@ -63,6 +63,8 @@ The ID of the robot that the localization command is sent to.
 -----------
 
 ## SubscribeEmergencyStopStatus
+Streaming mode: [`event`](../../index.md#event-based)
+
 A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) endpoint to Subscribe to the software emergency stop state. Upon subscription, the latest emergency stop state is sent immediately. State updates are streamed whenever the emergency stop state changes.
 
 ### Request
@@ -124,6 +126,8 @@ The current emergency stop state of the robot.
 
 -----------
 ## SubscribeLocalizationStatus
+Streaming mode: [`event`](../../index.md#event-based)
+
 A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) endpoint to get the robot’s localization state. Upon subscription, the latest localization state is sent immediately. State updates are streamed while localization is active.
 
 ### Request
@@ -176,6 +180,8 @@ The ID of the robot that subscription request is sent to.
 
 -----------
 ## SubscribeRobotPose
+Streaming mode: [`frequency`](../../index.md#frequency-based)
+
 A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) endpoint to subscribe to the robot's pose estimates at a regular frequency. (~10Hz) Use this to track the robot's position in real time.
 
 ### Request

--- a/docs/v1.1/resources/Mission.md
+++ b/docs/v1.1/resources/Mission.md
@@ -174,6 +174,8 @@ The ID of the robot that will receive this command.
 
 -----------
 ## SubscribeMissionStatus 
+Streaming mode: [`event`](../../index.md#event-based)
+
 A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) endpoint to get updates on the robot's mission state. Upon subscription, the latest known mission state is sent immediately. Subsequent updates are streamed as the state changes. 
 
 ### Request

--- a/docs/v1.1/resources/RobotStatus.md
+++ b/docs/v1.1/resources/RobotStatus.md
@@ -170,6 +170,8 @@ Robot type-specific state information. Only one type may be set at a time.
 
 -----------
 ## SubscribeBatteryStatus
+Streaming mode: [`event`](../../index.md#event-based)
+
 A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) endpoint to get battery state updates for the robot. Upon subscription, the latest battery state is sent immediately. Updates are streamed whenever the state changes.
 
 ### Request
@@ -270,6 +272,8 @@ Represents the state of the robot's battery system.
 
 -----------
 ## SubscribeRobotStatus
+Streaming mode: [`hybrid`](../../index.md#hybrid) · [When to use this vs. individual endpoints](../../index.md#consolidated-vs-individual)
+
 A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) endpoint to get the robot's connectivity and operational state. Upon subscription, the latest battery state is sent immediately. Updates are streamed as the robot's state changes.
 
 ### Request
@@ -378,6 +382,8 @@ The current robot state including connectivity, battery, emergency stop, mission
 
 -----------
 ## SubscribeErrorCodes
+Streaming mode: [`event`](../../index.md#event-based)
+
 A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) endpoint to subscribe to error codes returned by the robot. Upon subscription, the latest known error codes are sent immediately. Updates are streamed when error codes change.
 
 ### Request
@@ -474,6 +480,8 @@ Note that each robot maintains its own metadata, so messages should be correlate
 
 -----------
 ## SubscribeNetworkStatus
+Streaming mode: [`event`](../../index.md#event-based)
+
 A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) endpoint to subscribe to network status updates for robots. Upon subscription, the latest known network states are sent immediately. Updates are streamed when any network state changes.
 
 ### Request

--- a/docs/v1.1/resources/Servi.md
+++ b/docs/v1.1/resources/Servi.md
@@ -215,6 +215,8 @@ Selector to specify which trays to calibrate.
 
 -----------
 ## SubscribeTrayStatuses
+Streaming mode: [`event`](../../index.md#event-based)
+
 Subscribes to the robot's tray status updates. <br />
 Upon subscription, the latest known tray states are sent immediately. Updates are streamed when any tray state changes.
 

--- a/docs/v1.2/resources/Carti.md
+++ b/docs/v1.2/resources/Carti.md
@@ -181,6 +181,8 @@ List of available conveyor indexes for this robot.
 
 -----------
 ## SubscribeConveyorStatus
+Streaming mode: [`event`](../../index.md#event-based)
+
 A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) endpoint to get conveyor status updates for the robot.
 
 Upon subscription, the latest known conveyor states are sent immediately. Updates are streamed when any conveyor state changes.

--- a/docs/v1.2/resources/LocalizationAndNavigation.md
+++ b/docs/v1.2/resources/LocalizationAndNavigation.md
@@ -63,6 +63,8 @@ The ID of the robot that the localization command is sent to.
 -----------
 
 ## SubscribeEmergencyStopStatus
+Streaming mode: [`event`](../../index.md#event-based)
+
 A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) endpoint to Subscribe to the software emergency stop state.
 
 Upon subscription, the latest emergency stop state is sent immediately. State updates are streamed whenever the emergency stop state changes.
@@ -126,6 +128,8 @@ The current emergency stop state of the robot.
 
 -----------
 ## SubscribeLocalizationStatus
+Streaming mode: [`event`](../../index.md#event-based)
+
 A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) endpoint to get the robot’s localization state. Upon subscription, the latest localization state is sent immediately. State updates are streamed while localization is active.
 
 ### Request
@@ -178,6 +182,8 @@ The ID of the robot that subscription request is sent to.
 
 -----------
 ## SubscribeRobotPose
+Streaming mode: [`frequency`](../../index.md#frequency-based)
+
 A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) endpoint to subscribe to the robot's pose estimates at a regular frequency. (~10Hz)
 
 Use this to track the robot's position in real time.

--- a/docs/v1.2/resources/Mission.md
+++ b/docs/v1.2/resources/Mission.md
@@ -306,6 +306,8 @@ The ID of the mission where the goal was skipped.
 
 -----------
 ## SubscribeMissionStatus 
+Streaming mode: [`event`](../../index.md#event-based)
+
 A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) endpoint to get updates on the robot's mission state. Upon subscription, the latest known mission state is sent immediately. Subsequent updates are streamed as the state changes.
 
 ### Request

--- a/docs/v1.2/resources/RobotStatus.md
+++ b/docs/v1.2/resources/RobotStatus.md
@@ -183,6 +183,8 @@ Robot type-specific state information. Only one type may be set at a time.
 
 -----------
 ## SubscribeBatteryStatus
+Streaming mode: [`event`](../../index.md#event-based)
+
 A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) endpoint to get battery state updates for the robot.
 
 Upon subscription, the latest battery state is sent immediately. Updates are streamed whenever the state changes.
@@ -285,6 +287,8 @@ Represents the state of the robot's battery system.
 
 -----------
 ## SubscribeRobotStatus
+Streaming mode: [`hybrid`](../../index.md#hybrid) · [When to use this vs. individual endpoints](../../index.md#consolidated-vs-individual)
+
 A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) endpoint to get the robot's connectivity and operational state.
 
 Upon subscription, the latest battery state is sent immediately. Updates are streamed as the robot's state changes.
@@ -399,6 +403,8 @@ The current robot state including connectivity, battery, emergency stop, mission
 
 -----------
 ## SubscribeErrorCodes
+Streaming mode: [`event`](../../index.md#event-based)
+
 A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) endpoint to subscribe to error codes returned by the robot.
 
 Upon subscription, the latest known error codes are sent immediately. Updates are streamed when error codes change.
@@ -497,6 +503,8 @@ Note that each robot maintains its own metadata, so messages should be correlate
 
 -----------
 ## SubscribeNetworkStatus
+Streaming mode: [`event`](../../index.md#event-based)
+
 A [server side streaming RPC](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) endpoint to subscribe to network status updates for robots.
 
 Upon subscription, the latest known network states are sent immediately. Updates are streamed when any network state changes.

--- a/docs/v1.2/resources/Servi.md
+++ b/docs/v1.2/resources/Servi.md
@@ -229,6 +229,8 @@ Selector to specify which trays to calibrate.
 
 -----------
 ## SubscribeTrayStatuses
+Streaming mode: [`event`](../../index.md#event-based)
+
 Subscribes to the robot's tray status updates.
 
 Upon subscription, the latest known tray states are sent immediately. Updates are streamed when any tray state changes.


### PR DESCRIPTION
- Add streaming mode documentation and per-RPC tags across v1.0, v1.1, and v1.2

- Document three streaming modes (frequency-based, hybrid, event-based) in the Overview page under Streaming RPCs, explaining the behavioral differences and providing concrete examples for each.

- Add inline streaming mode tags linking back to the Overview on every Subscribe* RPC across v1.0, v1.1, and v1.2 API docs:
	- frequency: SubscribeRobotPose
	- hybrid: SubscribeRobotStatus
	- event: all other streaming RPCs

- Add a guidance section on when to use SubscribeRobotStatus (consolidated) vs. individual endpoints, with links added to all three API versions.