### PR TITLE
Emphasize the v1.3 Postman collection at the top of the changelog

### DIFF
--- a/docs/changelog/v1.3.md
+++ b/docs/changelog/v1.3.md
@@ -14,6 +14,9 @@ June 2026
 !!!note
     Bear Cloud API v1.3 is designed to be **backward compatible** with v1.2, so there should not be any issues working with the v1.2 gRPC APIs.
 
+!!! tip "New in v1.3: a Postman collection for the REST API"
+    v1.3 ships a ready-to-import [Postman collection](../v1.3/resources/RestAPI.md#postman-collection) covering every unary REST endpoint, with API-key (JWT) authentication wired up — import it for quick, code-free testing. See [Developer Resources](#developer-resources) for details.
+
 ### Minimum Robot Software Versions (for full support)
 
 1. Servi: 26.02


### PR DESCRIPTION
## Change
Add a prominent callout near the top of the v1.3 changelog highlighting the new REST **Postman collection**, linking down to the detailed *Developer Resources* entry — so the tooling addition is discoverable without scrolling to the bottom.

Single-line change to `docs/changelog/v1.3.md`; based on `main` (the v1.3 changelog landed via #51).

🤖 Generated with [Claude Code](https://claude.com/claude-code)