### PR TITLE
[BA-1201] Update public cloud v1 protos to v1.3

### DIFF
--- a/bearrobotics/api/v1/carti/conveyor.proto
+++ b/bearrobotics/api/v1/carti/conveyor.proto
@@ -1,6 +1,6 @@
 // File: conveyor.proto
 //
-// Copyright 2025 Bear Robotics, Inc. All rights reserved.
+// Copyright 2026 Bear Robotics, Inc. All rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -9,7 +9,6 @@
 syntax = "proto3";
 
 package bearrobotics.api.v1.carti;
-
 
 // The index is the logical position of the equipment on the robot,
 // and it does not indicate the physical height/position of the conveyor.

--- a/bearrobotics/api/v1/carti/mission.proto
+++ b/bearrobotics/api/v1/carti/mission.proto
@@ -1,6 +1,6 @@
 // File: mission.proto
 //
-// Copyright 2025 Bear Robotics, Inc. All rights reserved.
+// Copyright 2026 Bear Robotics, Inc. All rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -11,7 +11,6 @@ syntax = "proto3";
 package bearrobotics.api.v1.carti;
 
 import "bearrobotics/api/v1/core/annotation.proto";
-
 
 // Feedback provides status updates on mission progress,
 // specific to Carti Family robot missions.
@@ -102,5 +101,28 @@ message Mission {
 
     // An automated navigation mission that selects the best available goal from a list.
     NavigateAutoMission navigate_auto_mission = 4;
+  }
+}
+
+message TraverseWorkflow {
+  // Workflow for traverse missions.
+  // Corresponds to Touchscreen UI:
+  // - Table option
+  repeated core.Goal goals = 1;
+}
+
+message TraversePatrolWorkflow {
+  // Workflow for traverse patrol missions.
+  // Corresponds to Touchscreen UI:
+  // - Patrol option
+  repeated core.Goal goals = 1;
+}
+
+// Carti workflows are specific to the Carti family and mirror touchscreen
+// behavior.
+message MissionWorkflow {
+  oneof workflow {
+    TraverseWorkflow traverse = 1;
+    TraversePatrolWorkflow traverse_patrol = 2;
   }
 }

--- a/bearrobotics/api/v1/core/annotation.proto
+++ b/bearrobotics/api/v1/core/annotation.proto
@@ -1,6 +1,6 @@
 // File: annotation.proto
 //
-// Copyright 2025 Bear Robotics, Inc. All rights reserved.
+// Copyright 2026 Bear Robotics, Inc. All rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -12,7 +12,6 @@ package bearrobotics.api.v1.core;
 
 import "bearrobotics/api/v1/core/pose.proto";
 import "google/protobuf/timestamp.proto";
-
 
 // Destination represents a single point of interest on the map
 // that a robot can navigate to and align itself with.

--- a/bearrobotics/api/v1/core/errors.proto
+++ b/bearrobotics/api/v1/core/errors.proto
@@ -1,6 +1,6 @@
 // File: errors.proto
 //
-// Copyright 2025 Bear Robotics, Inc. All rights reserved.
+// Copyright 2026 Bear Robotics, Inc. All rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -11,7 +11,6 @@ syntax = "proto3";
 package bearrobotics.api.v1.core;
 
 import "bearrobotics/api/v1/core/metadata.proto";
-
 
 message ErrorCode {
   // Integer code indicating the type of error. Does not indicate severity.

--- a/bearrobotics/api/v1/core/fleet_selector.proto
+++ b/bearrobotics/api/v1/core/fleet_selector.proto
@@ -1,6 +1,6 @@
 // File: fleet_selector.proto
 //
-// Copyright 2025 Bear Robotics, Inc. All rights reserved.
+// Copyright 2026 Bear Robotics, Inc. All rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -9,7 +9,6 @@
 syntax = "proto3";
 
 package bearrobotics.api.v1.core;
-
 
 // RobotFilter defines the conditions for selecting robots.
 message RobotFilter {

--- a/bearrobotics/api/v1/core/localization.proto
+++ b/bearrobotics/api/v1/core/localization.proto
@@ -1,6 +1,6 @@
 // File: localization.proto
 //
-// Copyright 2025 Bear Robotics, Inc. All rights reserved.
+// Copyright 2026 Bear Robotics, Inc. All rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -10,21 +10,27 @@ syntax = "proto3";
 
 package bearrobotics.api.v1.core;
 
-
 // Represents the current state of the localization process.
 message LocalizationState {
   // Current state of the localization process.
   enum State {
     STATE_UNKNOWN = 0;
 
-    // Localization failed.
+    // Localization failed (service error, timeout, or initialization
+    // failure).
     STATE_FAILED = 1;
 
-    // Localization completed successfully.
+    // Localization completed successfully and the pose is trusted.
     STATE_SUCCEEDED = 2;
 
     // The robot is actively attempting to localize.
     STATE_LOCALIZING = 3;
+
+    // The robot believes it has lost its pose and needs relocalization
+    // (e.g., scan-matching confidence has dropped below threshold).
+    // Distinct from STATE_FAILED: localization is still running but its
+    // current estimate is no longer trusted.
+    STATE_MISLOCALIZED = 4;
   }
   State state = 2;
 }

--- a/bearrobotics/api/v1/core/location.proto
+++ b/bearrobotics/api/v1/core/location.proto
@@ -1,6 +1,6 @@
 // File: location.proto
 //
-// Copyright 2025 Bear Robotics, Inc. All rights reserved.
+// Copyright 2026 Bear Robotics, Inc. All rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -12,15 +12,15 @@ package bearrobotics.api.v1.core;
 
 import "google/protobuf/timestamp.proto";
 
-
 // Location represents a physical location with multiple floors and sections,
 // including metadata such as creation and modification timestamps.
 message Location {
-  // A 4 character alphanumeric identifier for the location. This is unique
-  // among all locations in a Universe.
-  // Example: "3R0A"
+  // A unique identifier for the location, scoped to a Universe. Up to 36
+  // characters of [A-Z0-9]; newly generated IDs are 4-6 character uppercase
+  // alphanumeric.
+  // Examples: "LOCA", "WGXIQ", "ABC123"
   // Legacy locations may use the display_name as the identifier, in which case
-  // the identifier may be longer or shorter than 4 characters.
+  // the identifier may use other formats.
   string location_id = 1;
 
   // Timestamp indicating when the location was created.

--- a/bearrobotics/api/v1/core/map.proto
+++ b/bearrobotics/api/v1/core/map.proto
@@ -1,6 +1,6 @@
 // File: map.proto
 //
-// Copyright 2025 Bear Robotics, Inc. All rights reserved.
+// Copyright 2026 Bear Robotics, Inc. All rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -12,7 +12,6 @@ package bearrobotics.api.v1.core;
 
 import "bearrobotics/api/v1/core/annotation.proto";
 import "google/protobuf/timestamp.proto";
-
 
 // Origin represents the starting point of the map in terms of its coordinates and orientation.
 message Origin {
@@ -28,10 +27,12 @@ message Origin {
 
 // MapImageFileInfo contains metadata about the map image file for integrity verification.
 message MapImageFileInfo {
-  // CRC32C checksum of the map image file.
+  // [Deprecated] CRC32C checksum. Use md5_checksum instead.
   uint32 checksum = 1;
   // Size of the map image file in bytes.
   int64 size = 2;
+  // MD5 checksum represented as a 32-character lowercase hexadecimal string.
+  string md5_checksum = 3;
 }
 
 // SignedURL represents a signed URL for file access with expiration.

--- a/bearrobotics/api/v1/core/metadata.proto
+++ b/bearrobotics/api/v1/core/metadata.proto
@@ -1,6 +1,6 @@
 // File: metadata.proto
 //
-// Copyright 2025 Bear Robotics, Inc. All rights reserved.
+// Copyright 2026 Bear Robotics, Inc. All rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -11,7 +11,6 @@ syntax = "proto3";
 package bearrobotics.api.v1.core;
 
 import "google/protobuf/timestamp.proto";
-
 
 // EventMetadata is a message returned by streaming endpoints.
 message EventMetadata {

--- a/bearrobotics/api/v1/core/mission.proto
+++ b/bearrobotics/api/v1/core/mission.proto
@@ -1,6 +1,6 @@
 // File: mission.proto
 //
-// Copyright 2025 Bear Robotics, Inc. All rights reserved.
+// Copyright 2026 Bear Robotics, Inc. All rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -14,7 +14,6 @@ import "bearrobotics/api/v1/carti/mission.proto";
 import "bearrobotics/api/v1/core/annotation.proto";
 import "bearrobotics/api/v1/servi/mission.proto";
 import "google/protobuf/any.proto";
-
 
 // A mission that automatically selects the first unoccupied and unclaimed goal
 // from the provided list, preferring goals with lower index values.
@@ -93,4 +92,16 @@ message MissionCommand {
     COMMAND_FINISH = 4;
   }
   Command command = 2;
+}
+
+// Workflows mirror touchscreen behavior and presets (including automatic
+// return selection).
+message MissionWorkflow {
+  oneof workflow {
+    // Servi workflow
+    servi.MissionWorkflow servi_workflow = 1;
+
+    // Carti workflow
+    carti.MissionWorkflow carti_workflow = 2;
+  }
 }

--- a/bearrobotics/api/v1/core/mission_status.proto
+++ b/bearrobotics/api/v1/core/mission_status.proto
@@ -1,6 +1,6 @@
 // File: mission_status.proto
 //
-// Copyright 2025 Bear Robotics, Inc. All rights reserved.
+// Copyright 2026 Bear Robotics, Inc. All rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -14,7 +14,6 @@ import "bearrobotics/api/v1/carti/mission.proto";
 import "bearrobotics/api/v1/core/annotation.proto";
 import "bearrobotics/api/v1/core/mission.proto";
 import "bearrobotics/api/v1/servi/mission.proto";
-
 
 // BaseFeedback provides status updates on mission progress,
 // specific to base missions.

--- a/bearrobotics/api/v1/core/network_status.proto
+++ b/bearrobotics/api/v1/core/network_status.proto
@@ -1,6 +1,6 @@
 // File: network_status.proto
 //
-// Copyright 2025 Bear Robotics, Inc. All rights reserved.
+// Copyright 2026 Bear Robotics, Inc. All rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -11,7 +11,6 @@ syntax = "proto3";
 package bearrobotics.api.v1.core;
 
 import "bearrobotics/api/v1/core/metadata.proto";
-
 
 // Represents the Wifi connection of a robot.
 message Wifi {

--- a/bearrobotics/api/v1/core/pose.proto
+++ b/bearrobotics/api/v1/core/pose.proto
@@ -1,6 +1,6 @@
 // File: pose.proto
 //
-// Copyright 2025 Bear Robotics, Inc. All rights reserved.
+// Copyright 2026 Bear Robotics, Inc. All rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -11,7 +11,6 @@ syntax = "proto3";
 package bearrobotics.api.v1.core;
 
 import "bearrobotics/api/v1/core/metadata.proto";
-
 
 // Represents the robot's pose on the map.
 message Pose {

--- a/bearrobotics/api/v1/core/robot_status.proto
+++ b/bearrobotics/api/v1/core/robot_status.proto
@@ -1,6 +1,6 @@
 // File: robot_status.proto
 //
-// Copyright 2025 Bear Robotics, Inc. All rights reserved.
+// Copyright 2026 Bear Robotics, Inc. All rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -12,10 +12,12 @@ package bearrobotics.api.v1.core;
 
 import "bearrobotics/api/v1/carti/conveyor.proto";
 import "bearrobotics/api/v1/core/errors.proto";
+import "bearrobotics/api/v1/core/localization.proto";
+import "bearrobotics/api/v1/core/metadata.proto";
 import "bearrobotics/api/v1/core/mission_status.proto";
 import "bearrobotics/api/v1/core/pose.proto";
+import "bearrobotics/api/v1/core/twist.proto";
 import "bearrobotics/api/v1/servi/tray_status.proto";
-
 
 // Represents the state of the robot's battery system.
 message BatteryState {
@@ -88,6 +90,15 @@ message RobotConnection {
   State state = 1;
 }
 
+// Represents the current online connection state of the robot.
+message RobotConnectionWithMetadata {
+  // Metadata associated with the event.
+  core.EventMetadata metadata = 1;
+
+  // Connection state of the robot.
+  RobotConnection connection = 2;
+}
+
 // Represents the set of robot states specifically for Servi robots.
 message ServiState {
   // A collection of individual tray states from different trays.
@@ -98,6 +109,67 @@ message ServiState {
 message CartiState {
   // Conveyor state, only available for robots with a conveyor installed.
   optional carti.ConveyorState conveyor_state = 1;
+}
+
+// Represents whether the robot is currently unable to make navigation
+// progress, and the reason for it when known.
+//
+// "Stuck" is distinct from a mission failure: it is a transient,
+// recoverable navigation condition (e.g., obstruction, restricted area)
+// in which the robot has stopped moving but is otherwise healthy.
+message StuckState {
+  // High-level stuck state of the robot.
+  enum State {
+    // Default unset value. Treat as an error if received.
+    STATE_UNKNOWN = 0;
+
+    // The robot is operating normally and not stuck.
+    STATE_NOT_STUCK = 1;
+
+    // The robot is unable to make navigation progress.
+    // See `reason` for the cause when available.
+    STATE_STUCK = 2;
+  }
+
+  // Current stuck state of the robot.
+  State state = 1;
+
+  // Reason the robot is stuck.
+  //
+  // Only meaningful when state == STATE_STUCK; otherwise expect
+  // REASON_UNKNOWN. Some reasons may be REASON_UNKNOWN even when stuck
+  // because the upstream navigation stack does not always surface a
+  // discrete cause.
+  enum Reason {
+    // No reason reported. Set when state != STATE_STUCK, or when the
+    // upstream stack did not provide a discrete cause.
+    REASON_UNKNOWN = 0;
+
+    // The planned path is blocked at runtime by a dynamic obstacle.
+    REASON_PATH_BLOCKED = 1;
+
+    // The destination cell is occupied by an obstacle. Reserved for
+    // future use; not currently emitted by the robot.
+    REASON_DESTINATION_OBSTRUCTED = 2;
+
+    // No feasible path exists to the destination. Reserved for future
+    // use; not currently emitted by the robot.
+    REASON_DESTINATION_UNREACHABLE = 3;
+
+    // The robot is inside a restricted/annotated area it cannot leave
+    // (e.g., a no-go zone it was placed into).
+    REASON_INSIDE_RESTRICTED_AREA = 4;
+  }
+
+  // Reason the robot is stuck. See `Reason` for semantics.
+  Reason reason = 2;
+}
+
+// Represents navigation-related state for the robot.
+message NavigationState {
+  // Whether the robot is currently stuck (unable to make navigation
+  // progress) and, when known, the reason.
+  StuckState stuck_state = 1;
 }
 
 // Represents the overall state of the robot.
@@ -126,4 +198,13 @@ message RobotState {
     // Populated when the robot type is a Carti.
     CartiState carti_state = 8;
   }
+
+  // Linear and angular velocity of the robot.
+  core.Twist twist = 9;
+
+  // Localization state of the robot.
+  core.LocalizationState localization_state = 10;
+
+  // Navigation-related state of the robot.
+  NavigationState navigation_state = 11;
 }

--- a/bearrobotics/api/v1/core/robot_system.proto
+++ b/bearrobotics/api/v1/core/robot_system.proto
@@ -1,6 +1,6 @@
 // File: robot_system.proto
 //
-// Copyright 2025 Bear Robotics, Inc. All rights reserved.
+// Copyright 2026 Bear Robotics, Inc. All rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -9,7 +9,6 @@
 syntax = "proto3";
 
 package bearrobotics.api.v1.core;
-
 
 // Robot-level system operation to be executed.
 message SystemCommand {
@@ -27,9 +26,14 @@ message SystemCommand {
     Type type = 1;
   }
 
+  // Shuts down the robot system.
+  // Pass in an empty Shutdown message to initiate a shutdown.
+  message Shutdown {}
+
   // Client-specified system command to be executed.
   oneof command {
     Reboot reboot = 1;
+    Shutdown shutdown = 2;
   }
 }
 
@@ -48,6 +52,7 @@ message SystemInfo {
     ROBOT_FAMILY_SERVI_LIFT = 4;
     ROBOT_FAMILY_CARTI_100 = 5;
     ROBOT_FAMILY_CARTI_600 = 6;
+    ROBOT_FAMILY_SERVI_Q = 7;
   }
   RobotFamily robot_family = 2;
 

--- a/bearrobotics/api/v1/core/twist.proto
+++ b/bearrobotics/api/v1/core/twist.proto
@@ -1,0 +1,34 @@
+// File: twist.proto
+//
+// Copyright 2026 Bear Robotics, Inc. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+syntax = "proto3";
+
+package bearrobotics.api.v1.core;
+
+import "bearrobotics/api/v1/core/metadata.proto";
+
+// Represents velocity in 2D space in linear and angular components.
+message Twist {
+  // The desired speed to drive up to in meters-per-second (m/s).
+  // A positive value should be used for driving forward and a negative
+  // value may be used to drive in reverse.
+  float linear_velocity = 1;
+
+  // The desired rate of rotation in radians-per-second (rad/s).
+  // A positive value is used for a clockwise (right) point turn while a
+  // negative value should be used for counter-clockwise (left) point turn.
+  float angular_velocity = 2;
+}
+
+message TwistWithMetadata {
+  // Metadata associated with the event.
+  EventMetadata metadata = 1;
+
+  // Linear and angular velocity of the robot at the time of publication.
+  Twist twist = 2;
+}

--- a/bearrobotics/api/v1/core/webhook.proto
+++ b/bearrobotics/api/v1/core/webhook.proto
@@ -1,0 +1,151 @@
+// File: webhook.proto
+//
+// Copyright 2026 Bear Robotics, Inc. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+syntax = "proto3";
+
+package bearrobotics.api.v1.core;
+
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+
+// WebhookOptions contains optional delivery customizations for a webhook
+// subscription.
+message WebhookOptions {
+  // Optional human-readable description of the webhook.
+  optional string description = 1;
+
+  // Optional request template for customizing the delivered payload.
+  // Keys are output field names; values are template strings with
+  // placeholders referencing event fields using "{{field_path}}" syntax.
+  //
+  // Example JSON:
+  //   {
+  //     "robot": "{{robot_id}}",
+  //     "mission": "{{state.current_mission.mission_id}}",
+  //     "outcome": "{{state.current_mission.state}}"
+  //   }
+  //
+  // If unspecified, the payload would simply be the original message in JSON format.
+  google.protobuf.Struct request_template = 2;
+
+  // Optional custom HTTP headers to include in webhook delivery requests.
+  map<string, string> headers = 3;
+}
+
+// FilterOperator defines the comparison operators available for event
+// filtering.
+enum FilterOperator {
+  FILTER_OPERATOR_UNKNOWN = 0;
+  // Matches when the field value is contained in the provided values list.
+  FILTER_OPERATOR_IN = 1;
+}
+
+// FieldFilter defines a single field-level condition for event filtering.
+//
+// Example JSON:
+//   {
+//     "field": "state.current_mission.state",
+//     "operator": "FILTER_OPERATOR_IN",
+//     "values": ["STATE_SUCCEEDED", "STATE_FAILED", "STATE_CANCELED"]
+//   }
+message FieldFilter {
+  // Target field path to apply the filter on.
+  // The path should begin with "state", followed by a "."-separated list of field names
+  // determined by the payload structure.
+  string field = 1;
+
+  // Comparison operator to use.
+  FilterOperator operator = 2;
+
+  // Values to match against the target field.
+  repeated string values = 3;
+}
+
+// RobotIdList is a list of robot IDs for use inside a WebhookRobotSelector
+// oneof.
+message RobotIdList {
+  repeated string ids = 1;
+}
+
+// LocationIdList is a list of location IDs for use inside a
+// WebhookRobotSelector oneof.
+message LocationIdList {
+  repeated string ids = 1;
+}
+
+// WebhookRobotSelector specifies which robots a webhook subscription targets.
+// The caller must provide exactly one of the two options.
+message WebhookRobotSelector {
+  oneof selector {
+    // Explicit list of robot IDs.
+    RobotIdList robot_ids = 1;
+    // List of location IDs; the server resolves these to robot IDs via Fleet Info.
+    LocationIdList location_ids = 2;
+  }
+}
+
+// WebhookSubscription represents a registered webhook configuration.
+message WebhookSubscription {
+  // Unique identifier of the webhook subscription.
+  string id = 1;
+
+  // The distributor (client organization) ID that owns this subscription.
+  string distributor_id = 2;
+
+  // Optional human-readable description of the webhook.
+  optional string description = 3;
+
+  // The URL to deliver webhook events to.
+  string url = 4;
+
+  // Optional custom HTTP headers to include in webhook delivery requests.
+  map<string, string> headers = 5;
+
+  // Event type subscribed to (e.g., "mission", "battery").
+  string event_type = 6;
+
+  // The robot selector that was provided when creating the subscription.
+  WebhookRobotSelector selector = 7;
+
+  // Optional filter to control which events trigger delivery.
+  FieldFilter filter = 8;
+
+  // Optional request template for customizing the delivered payload.
+  // Keys are output field names; values are template strings with
+  // placeholders referencing event fields using "{{field_path}}" syntax.
+  // Only robot_id and scalar fields under state.*
+  // (e.g., state.current_mission.mission_id) may be referenced.
+  //
+  // Example JSON:
+  //   {
+  //     "robot": "{{robot_id}}",
+  //     "mission": "{{state.current_mission.mission_id}}",
+  //     "outcome": "{{state.current_mission.state}}"
+  //   }
+  //
+  // If unspecified, the payload would simply be the original message in JSON format.
+  google.protobuf.Struct request_template = 9;
+
+  // Whether this subscription is currently active.
+  bool enabled = 10;
+
+  // Timestamp when the subscription was created.
+  google.protobuf.Timestamp created_at = 11;
+
+  // Timestamp when the subscription was last updated.
+  google.protobuf.Timestamp updated_at = 12;
+
+  // Reason the subscription was automatically disabled after sustained
+  // delivery failures. Set on deactivation and cleared when the
+  // subscription is re-enabled.
+  optional string disabled_reason = 13;
+
+  // Timestamp when the subscription was disabled.
+  // Set and cleared together with disabled_reason.
+  google.protobuf.Timestamp disabled_at = 14;
+}

--- a/bearrobotics/api/v1/servi/mission.proto
+++ b/bearrobotics/api/v1/servi/mission.proto
@@ -1,6 +1,6 @@
 // File: mission.proto
 //
-// Copyright 2025 Bear Robotics, Inc. All rights reserved.
+// Copyright 2026 Bear Robotics, Inc. All rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -11,7 +11,6 @@ syntax = "proto3";
 package bearrobotics.api.v1.servi;
 
 import "bearrobotics/api/v1/core/annotation.proto";
-
 
 // Feedback provides status updates on mission progress,
 // specific to Servi Family robot missions.
@@ -145,5 +144,68 @@ message Mission {
 
     // An automated navigation mission that selects the best available goal from a list.
     NavigateAutoMission navigate_auto_mission = 6;
+  }
+}
+
+message DeliveryWorkflow {
+  // Workflow for delivery missions.
+  // Corresponds to Touchscreen UI:
+  // - Serving, Table option
+  repeated core.Goal goals = 1;
+}
+
+message DeliveryPatrolWorkflow {
+  // Workflow for delivery patrol missions.
+  // Corresponds to Touchscreen UI:
+  // - Serving, Patrol option
+  repeated core.Goal goals = 1;
+}
+
+message BussingWorkflow {
+  // Workflow for bussing missions.
+  // Corresponds to Touchscreen UI:
+  // - Bussing, Table option
+  repeated core.Goal goals = 1;
+}
+
+message BussingPatrolWorkflow {
+  // Workflow for bussing patrol missions.
+  // Corresponds to Touchscreen UI:
+  // - Bussing, Patrol option
+  repeated core.Goal goals = 1;
+}
+
+message BirthdayWorkflow {
+  // Workflow for Birthday Mission.
+  // Corresponds to Touchscreen UI:
+  // Birthday Mode
+  core.Goal goal = 1;
+}
+
+// Workflow for hosting missions.
+// Corresponds to Touchscreen UI:
+// - Hosting, Restaurant option
+message HostingWorkflow {
+  repeated core.Goal goals = 1;
+}
+
+// Workflow for hosting patrol missions.
+// Corresponds to Touchscreen UI:
+// - Hosting, Patrol option
+message HostingPatrolWorkflow {
+  repeated core.Goal goals = 1;
+}
+
+// Servi workflows are specific to the Servi family and mirror touchscreen
+// behavior.
+message MissionWorkflow {
+  oneof workflow {
+    DeliveryWorkflow delivery = 1;
+    DeliveryPatrolWorkflow delivery_patrol = 2;
+    BussingWorkflow bussing = 3;
+    BussingPatrolWorkflow bussing_patrol = 4;
+    BirthdayWorkflow birthday = 5;
+    HostingWorkflow hosting = 6;
+    HostingPatrolWorkflow hosting_patrol = 7;
   }
 }

--- a/bearrobotics/api/v1/servi/tray_status.proto
+++ b/bearrobotics/api/v1/servi/tray_status.proto
@@ -1,6 +1,6 @@
 // File: tray_status.proto
 //
-// Copyright 2025 Bear Robotics, Inc. All rights reserved.
+// Copyright 2026 Bear Robotics, Inc. All rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -11,7 +11,6 @@ syntax = "proto3";
 package bearrobotics.api.v1.servi;
 
 import "bearrobotics/api/v1/core/metadata.proto";
-
 
 // TraySelector defines a filter for selecting specific trays.
 // It supports selection by a list of tray names.

--- a/bearrobotics/api/v1/services/cloud/api_service.proto
+++ b/bearrobotics/api/v1/services/cloud/api_service.proto
@@ -1,6 +1,6 @@
 // File: api_service.proto
 //
-// Copyright 2025 Bear Robotics, Inc. All rights reserved.
+// Copyright 2026 Bear Robotics, Inc. All rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -24,6 +24,7 @@ import "bearrobotics/api/v1/core/network_status.proto";
 import "bearrobotics/api/v1/core/pose.proto";
 import "bearrobotics/api/v1/core/robot_status.proto";
 import "bearrobotics/api/v1/core/robot_system.proto";
+import "bearrobotics/api/v1/core/webhook.proto";
 import "bearrobotics/api/v1/servi/tray_status.proto";
 import "google/api/annotations.proto";
 
@@ -45,6 +46,16 @@ service APIService {
     option (google.api.http) = {post: "/v1/mission/append"};
   }
 
+  // Atomically append multiple missions to the end of the mission queue.
+  //
+  // All missions are appended contiguously in the request order.
+  // Missions can be appended even when other missions are queued.
+  //
+  // If any mission in the batch fails validation or append, no missions are appended.
+  rpc AppendMissionBatch(AppendMissionBatchRequest) returns (AppendMissionBatchResponse) {
+    option (google.api.http) = {post: "/v1/mission/append-batch"};
+  }
+
   // Instruct the robot to begin charging, regardless of its current battery
   // level.
   //
@@ -61,6 +72,13 @@ service APIService {
     option (google.api.http) = {post: "/v1/robot/charge"};
   }
 
+  // Clears the robot's mission status.
+  //
+  // The call will fail if the robot is on a running or paused mission.
+  rpc ClearMissionStatus(ClearMissionStatusRequest) returns (ClearMissionStatusResponse) {
+    option (google.api.http) = {post: "/v1/mission-status/clear"};
+  }
+
   // Create a new mission of a specified type.
   //
   // This call will fail if:
@@ -68,6 +86,46 @@ service APIService {
   // - The requested mission is not compatible with the robot's current state.
   rpc CreateMission(CreateMissionRequest) returns (CreateMissionResponse) {
     option (google.api.http) = {post: "/v1/mission/create"};
+  }
+
+  // Atomically create multiple missions.
+  //
+  // The returned mission IDs match the order of the missions in the request.
+  //
+  // This call will fail if:
+  // - Another mission is running or queued.
+  // - The robot is unable to start a mission.
+  //
+  // If any mission in the batch fails validation or creation, no missions are created.
+  rpc CreateMissionBatch(CreateMissionBatchRequest) returns (CreateMissionBatchResponse) {
+    option (google.api.http) = {post: "/v1/mission/create-batch"};
+  }
+
+  // Creates a new mission workflow that mirrors touchscreen presets,
+  // including automatic return point selection.
+  //
+  // This call will fail if:
+  // - The robot is already executing another mission.
+  //   Returns a FAILED_PRECONDITION error.
+  // - The requested workflow is not compatible with the robot's type or current state.
+  //   Returns an INVALID_ARGUMENT error.
+  //
+  // Returns the list of mission_ids for the created missions if successful.
+  rpc CreateMissionWorkflow(CreateMissionWorkflowRequest) returns (CreateMissionWorkflowResponse) {
+    option (google.api.http) = {post: "/v1/mission-workflow/create"};
+  }
+
+  // Moves to the next destination in the current mission.
+  //
+  // This call will fail if:
+  // - The robot is not on a mission.
+  //   Returns a FAILED_PRECONDITION error.
+  // - The skip goal request could not be delivered to the robot.
+  //   Returns an INTERNAL error.
+  //
+  // Returns the mission_id of the current mission where the goal was skipped.
+  rpc SkipGoal(SkipGoalRequest) returns (SkipGoalResponse) {
+    option (google.api.http) = {post: "/v1/goal/skip"};
   }
 
   // Subscribe to updates on the robot's mission status.
@@ -160,8 +218,14 @@ service APIService {
 
   // Subscribe to the software emergency stop state.
   //
-  // Upon subscription, the server sends the current emergency stop state,
-  // followed by updates whenever the emergency stop state changes.
+  // Upon subscription, the server sends the current emergency stop state of
+  // each selected robot, followed by updates whenever an emergency stop state
+  // changes. Each response carries the state of a single robot, identified by
+  // its robot_id.
+  //
+  // Errors:
+  //   - INVALID_ARGUMENT: Both robot_id and selector are set, neither is set,
+  //     or the selector does not select any robot.
   rpc SubscribeEmergencyStopStatus(SubscribeEmergencyStopStatusRequest) returns (stream SubscribeEmergencyStopStatusResponse);
 
   // Subscribe to the robot’s localization status.
@@ -172,9 +236,6 @@ service APIService {
   rpc SubscribeLocalizationStatus(SubscribeLocalizationStatusRequest) returns (stream SubscribeLocalizationStatusResponse);
 
   // Subscribe to the robot's pose estimates at a regular frequency. (~10Hz)
-  //
-  // Current implementation supports up to 5 robots. Requests with more than 5
-  // robots will return a INVALID_ARGUMENT error.
   //
   // Use this to track the robot's estimated position in real time.
   rpc SubscribeRobotPose(SubscribeRobotPoseRequest) returns (stream SubscribeRobotPoseResponse);
@@ -196,6 +257,24 @@ service APIService {
   // - The latest battery state is sent immediately.
   // - Updates are streamed whenever the state changes.
   rpc SubscribeBatteryStatus(SubscribeBatteryStatusRequest) returns (stream SubscribeBatteryStatusResponse);
+
+  // Subscribe to the navigation status of the selected robots.
+  //
+  // Upon subscription:
+  // - The latest known navigation status is sent immediately.
+  // - Updates are streamed when the navigation state changes.
+  //
+  // Each response carries the state of a single robot, identified by its
+  // robot_id.
+  //
+  // The stuck state indicates the robot is unable to make navigation progress
+  // (e.g., blocked by an obstacle or inside a restricted area) and is
+  // distinct from a mission failure.
+  //
+  // Prefer this RPC over SubscribeRobotStatus when only the navigation signal
+  // is of interest; the full robot status carries more data and updates
+  // more frequently.
+  rpc SubscribeNavigationStatus(SubscribeNavigationStatusRequest) returns (stream SubscribeNavigationStatusResponse);
 
   // Subscribe to the robot's connectivity and operational state.
   //
@@ -226,6 +305,13 @@ service APIService {
   //
   // Network status will include Wi-Fi and connectivity info.
   rpc SubscribeNetworkStatus(SubscribeNetworkStatusRequest) returns (stream SubscribeNetworkStatusResponse);
+
+  // Subscribe to the cloud-to-robot connection state for a fleet of robots.
+  //
+  // Upon subscription:
+  // - The latest known connection state for each selected robot is sent immediately.
+  // - Updates are streamed as robots connect or disconnect.
+  rpc SubscribeOnlineStatus(SubscribeOnlineStatusRequest) returns (stream SubscribeOnlineStatusResponse);
 
   // === Errors ===============================================================
 
@@ -327,6 +413,45 @@ service APIService {
   // - Payload detection may have false positives due to beam sensor
   //   limitations.
   rpc SubscribeConveyorStatus(SubscribeConveyorStatusRequest) returns (stream SubscribeConveyorStatusResponse);
+
+  // === Webhook ==============================================================
+  // These endpoints define the API for managing webhooks.
+  // They provide clients with a RESTful way of receiving streaming updates,
+  // serving as an alternative to gRPC streaming endpoints.
+
+  // Creates a new webhook subscription.
+  //
+  // Once created, a webhook subscription delivers an update via POST request
+  // to the given URL each time an event matching the given type and filter
+  // occurs on any of the selected robots.
+  //
+  // The delivery request payload content is customizable
+  // via the request template option.
+  //
+  // The client may also provide custom HTTP headers to include in each
+  // webhook delivery request.
+  rpc CreateWebhook(CreateWebhookRequest) returns (CreateWebhookResponse) {
+    option (google.api.http) = {post: "/v1/webhook/create"};
+  }
+
+  // Deletes an existing webhook subscription by ID (soft delete).
+  rpc DeleteWebhook(DeleteWebhookRequest) returns (DeleteWebhookResponse) {
+    option (google.api.http) = {post: "/v1/webhook/delete"};
+  }
+
+  // Lists all webhook subscriptions owned by the authenticated distributor.
+  rpc ListWebhooks(ListWebhooksRequest) returns (ListWebhooksResponse) {
+    option (google.api.http) = {post: "/v1/webhook/list"};
+  }
+}
+
+message AppendMissionBatchRequest {
+  string robot_id = 1;
+  repeated core.Mission missions = 2;
+}
+
+message AppendMissionBatchResponse {
+  repeated string mission_ids = 1;
 }
 
 message AppendMissionRequest {
@@ -353,12 +478,30 @@ message ChargeRobotResponse {
   string mission_id = 1;
 }
 
+message ClearMissionStatusRequest {
+  string robot_id = 1;
+}
+
+message ClearMissionStatusResponse {
+  // The unique identifiers of the cleared missions.
+  repeated string mission_ids = 1;
+}
+
 message ControlConveyorRequest {
   string robot_id = 1;
   repeated carti.ConveyorMotorCommand commands = 2;
 }
 
 message ControlConveyorResponse {}
+
+message CreateMissionBatchRequest {
+  string robot_id = 1;
+  repeated core.Mission missions = 2;
+}
+
+message CreateMissionBatchResponse {
+  repeated string mission_ids = 1;
+}
 
 message CreateMissionRequest {
   string robot_id = 1;
@@ -368,6 +511,49 @@ message CreateMissionRequest {
 message CreateMissionResponse {
   string mission_id = 1;
 }
+
+message CreateMissionWorkflowRequest {
+  string robot_id = 1;
+  core.MissionWorkflow mission_workflow = 2;
+}
+
+message CreateMissionWorkflowResponse {
+  repeated string mission_ids = 1;
+}
+
+message CreateWebhookRequest {
+  // The URL to deliver webhook events to.
+  string url = 2;
+
+  // Event type to subscribe to.
+  // Supported event types:
+  // - "mission"
+  // - "battery"
+  string event_type = 3;
+
+  // Required robot selector: specifies which robots this webhook targets.
+  // Provide either explicit robot IDs or location IDs (resolved to robots
+  // via Fleet Info).
+  core.WebhookRobotSelector selector = 4;
+
+  // Optional filter to control which events trigger delivery.
+  core.FieldFilter filter = 5;
+
+  // Optional delivery customizations (template, headers, description).
+  core.WebhookOptions options = 6;
+}
+
+message CreateWebhookResponse {
+  // The newly created webhook subscription.
+  core.WebhookSubscription webhook = 1;
+}
+
+message DeleteWebhookRequest {
+  // Unique identifier of the webhook subscription to delete.
+  string id = 1;
+}
+
+message DeleteWebhookResponse {}
 
 message GetAvailableLocationsRequest {}
 
@@ -395,8 +581,10 @@ message GetCurrentMapResponse {
 }
 
 message GetLocationInfoRequest {
-  // The location_id is a 4 character alphanumeric identifier for the location.
-  // Example: "3R0A"
+  // A unique identifier for the location, scoped to a Universe. Up to 36
+  // characters of [A-Z0-9]; newly generated IDs are 4-6 character uppercase
+  // alphanumeric.
+  // Examples: "LOCA", "WGXIQ", "ABC123"
   string location_id = 1;
 }
 
@@ -441,6 +629,13 @@ message ListRobotIDsResponse {
   repeated string robot_ids = 2;
 }
 
+message ListWebhooksRequest {}
+
+message ListWebhooksResponse {
+  // The list of webhook subscriptions owned by the authenticated distributor.
+  repeated core.WebhookSubscription webhooks = 1;
+}
+
 message LocalizeRobotRequest {
   string robot_id = 1;
   core.Goal goal = 2;
@@ -462,6 +657,15 @@ message SetPoseRequest {
 
 message SetPoseResponse {}
 
+message SkipGoalRequest {
+  string robot_id = 1;
+}
+
+message SkipGoalResponse {
+  // The unique identifier of the mission where the goal was skipped.
+  string mission_id = 1;
+}
+
 message SubscribeBatteryStatusRequest {
   core.RobotSelector selector = 1;
 }
@@ -481,12 +685,30 @@ message SubscribeConveyorStatusResponse {
 }
 
 message SubscribeEmergencyStopStatusRequest {
-  string robot_id = 1;
+  // The unique robot identifier. E.g. "pennybot-abc123"
+  //
+  // Deprecated: use selector instead. Setting robot_id is equivalent to
+  // setting selector.robot_ids with a single ID. It remains supported for
+  // backwards compatibility.
+  string robot_id = 1 [deprecated = true];
+
+  // Selects the robots to subscribe to, by explicit robot IDs or by location.
+  //
+  // Exactly one of robot_id or selector must be set; setting both (or
+  // neither) returns an INVALID_ARGUMENT error.
+  core.RobotSelector selector = 2;
 }
 
 message SubscribeEmergencyStopStatusResponse {
   core.EventMetadata metadata = 1;
   core.EmergencyStopState e_stop_state = 2;
+
+  // ID of the robot this event pertains to. E.g. "pennybot-abc123"
+  // Always set, including for single-robot subscriptions made via the
+  // deprecated robot_id request field.
+  // Note that each robot maintains its own metadata, so messages should be
+  // correlated if and only if they correspond to the same robot ID.
+  string robot_id = 3;
 }
 
 message SubscribeErrorCodesRequest {
@@ -525,6 +747,22 @@ message SubscribeMissionStatusResponse {
   core.MissionStates mission_states = 4;
 }
 
+message SubscribeNavigationStatusRequest {
+  // Selects the robots to subscribe to, by explicit robot IDs or by location.
+  core.RobotSelector selector = 1;
+}
+
+message SubscribeNavigationStatusResponse {
+  core.EventMetadata metadata = 1;
+
+  // ID of the robot this event pertains to. E.g. "pennybot-abc123"
+  // Note that each robot maintains its own metadata, so messages should be
+  // correlated if and only if they correspond to the same robot ID.
+  string robot_id = 2;
+
+  core.NavigationState navigation_state = 3;
+}
+
 message SubscribeNetworkStatusRequest {
   core.RobotSelector selector = 1;
 }
@@ -536,6 +774,19 @@ message SubscribeNetworkStatusResponse {
   // Note that each robot maintains its own metadata, so messages should be
   // correlated if and only if they correspond to the same robot ID.
   map<string, core.NetworkStateWithMetadata> network_states = 1;
+}
+
+message SubscribeOnlineStatusRequest {
+  core.RobotSelector selector = 1;
+}
+
+message SubscribeOnlineStatusResponse {
+  // A mapping of online states reported by individual robots.
+  // Each entry pairs a robot ID (key) with its corresponding connection state
+  // and metadata.
+  // Note that each robot maintains its own metadata, so messages should be
+  // correlated if and only if they correspond to the same robot ID.
+  map<string, core.RobotConnectionWithMetadata> online_states = 1;
 }
 
 message SubscribeRobotPoseRequest {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Bear Cloud API
 site_url: https://bearrobotics-public.github.io/cloud/
-copyright: Copyright 2025 Bear Robotics, Inc. All rights reserved.
+copyright: Copyright 2026 Bear Robotics, Inc. All rights reserved.
 theme:
   name: material
   font:


### PR DESCRIPTION
Changelog
=====
Sync `bearrobotics/api/v1` in the public cloud repo from v1.1 to v1.3

**New RPCs (8):**
- Webhooks: `CreateWebhook`, `ListWebhooks`, `DeleteWebhook`
- Robot status: `SubscribeNavigationStatus`, `SubscribeOnlineStatus`
- Mission: `CreateMissionBatch`, `AppendMissionBatch`, `ClearMissionStatus`

**Field enhancements:**
- navigation_state / localization_state on `RobotState`
- fleet-level `SubscribeEmergencyStopStatus` (`RobotSelector`)
- md5_checksum on `GetMap` / `GetCurrentMap` (crc32c deprecated)

**New files:** 
- `core/webhook.proto` (webhooks)
- `core/twist.proto` (robot_status dependency)

**Also:**
- Redact REST (google.api.http) options from server-streaming RPCs (REST is unary-only)
- Reword internal-only reference in the SkipGoal doc comment
- Minor formatting: add blank line between `SkipGoal` messages, wrap over-length comments to <=79 cols, pad the `Webhook` section separator